### PR TITLE
Add a special user search option

### DIFF
--- a/ForgeRock Cloud APIs.postman_collection.json
+++ b/ForgeRock Cloud APIs.postman_collection.json
@@ -1,8 +1,8 @@
 {
 	"info": {
-		"_postman_id": "243df834-bc03-42f0-b9ff-cfa47b455a6a",
-		"name": "ForgeRock Cloud APIs (Apr 2019)",
-		"description": "The ForgeRock Identity Cloud includes two sets of APIs:\n\n* Authentication APIs: Allows you to authenticate users into your apps.\n\n* Management APIs: Supports management of objects such as users.\n\nNote: Many of the REST calls in this collection require that you have set up a web app, using the steps described in our documentation on <a href=\"https://developer-cloud.forgerock.com/sdks/nodejs/\" target=\"_blank\">SDKs: Web App (Node.js SDK)</a>.\n\nSome of these REST calls include scopes, which specify access rights as described in our documentation on <a href=\"https://developer-cloud.forgerock.com/reference/scopes/\" target=\"_blank\">scopes</a>. Use that guidance to set up the scopes property in your Postman collection.\n\nThe scopes that you specify in REST calls should be included in relevant apps. When you create an app in the UI, you can identify and update these scopes under the \"API Scopes\" tab. \n\n<p>\n\nThis collecition is set up with the following environment: ForgeRock Environment Vars 0.3. You can use the environment to pre-populate your REST calls. For more information, see the following section on <a href=\"https://developer-cloud.forgerock.com/apis/apis/\" target=\"_blank\">REST APIs</a>.\n\nSome REST calls are configured to \"pre-populate\" others; for example, when you run the POST Get Web App Token - Password Grant call, the output pre-populates values for userAccessToken, refreshToken, and userIdToken.\n\nAll example responses are based on cURL.",
+		"_postman_id": "b43ab656-9ce4-43c6-bbf9-0f1e8e252804",
+		"name": "ForgeRock Cloud APIs (Apr 2019.2)",
+		"description": "The ForgeRock Identity Cloud includes two sets of APIs:\n\n* Authentication APIs: Allows you to authenticate users into your apps.\n\n* Management APIs: Supports management of objects such as users.\n\nNote: Many of the REST calls in this collection require that you have set up a web app, using the steps described in our documentation on <a href=\"https://developer-cloud.forgerock.com/sdks/nodejs/\" target=\"_blank\">SDKs: Web App (Node.js SDK)</a>.\n\nSome of these REST calls include scopes, which specify access rights as described in our documentation on <a href=\"https://developer-cloud.forgerock.com/reference/scopes/\" target=\"_blank\">scopes</a>. Use that guidance to set up the scopes property in your Postman collection.\n\nThe scopes that you specify in REST calls should be included in relevant apps. When you create an app in the UI, you can identify and update these scopes under the \"API Scopes\" tab. \n\n<p>\n\nThis collection is set up with the following environment: ForgeRock Environment Vars 0.3. You can use the environment to pre-populate your REST calls. For more information, see the following section on <a href=\"https://developer-cloud.forgerock.com/apis/apis/\" target=\"_blank\">REST APIs</a>.\n\nSome REST calls are configured to \"pre-populate\" others; for example, when you run the POST Get Web App Token - Password Grant call, the output pre-populates values for userAccessToken, refreshToken, and userIdToken.\n\nAll example responses are based on cURL.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -2876,6 +2876,162 @@
 							]
 						},
 						{
+							"name": "Get users with conditions",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "570678be-7344-4365-83fa-236eeff8b588",
+										"exec": [
+											"var jsonData = JSON.parse(responseBody);",
+											"postman.setEnvironmentVariable(\"userId\", jsonData.id);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{accessToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/x-www-form-urlencoded"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{tenantApiV1Url}}/users?{{parameter}}={{userProperty}}%20{{comparator}}%20%22{{value}}%22",
+									"host": [
+										"{{tenantApiV1Url}}"
+									],
+									"path": [
+										"users"
+									],
+									"query": [
+										{
+											"key": "{{parameter}}",
+											"value": "{{userProperty}}%20{{comparator}}%20%22{{value}}%22"
+										}
+									]
+								},
+								"description": "Returns a paged list of end users. You can limit output based on parameters with conditions, as discussed in our documentation on <a href=\"https://developer-cloud.forgerock.com/apis/apis-filtering/\" target=\"_blank\">Querying Users</a>.\n\nThis call provides a model, with the following options added to the endpoint:\n\n* *parameter*: May be `filter`, `startIndex`, `count`, `fields`, `sortBy`\n* *userProperty*: Set to any valid user property \n* *comparator*: Use an operator that compares JSON values\n* *value*: Must be a valid value\n\nThe example request shown in the right-hand column performs a conditional search for users, with the following options:\n\n* `filter` (*parameter*) that searches for a\n* `userName` (*userProperty*) that's set\n* `eq` (equals) (*comparator*) to\n* `bjensen@example.com` (*value*).\n\nThe `%20` and `%22` in the example request URI represent a space and a double-quote, respectively, encoded in UTF-8 format.\n\nBased on the example request, you'll see user information for `bjensen@example.com` in the example response."
+							},
+							"response": [
+								{
+									"name": "Get users with conditions",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/x-www-form-urlencoded"
+											},
+											{
+												"key": "Authentication",
+												"value": "Bearer ACCESS_TOKEN",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "http://api.TENANT_NAME.forgeblocks.com/users?filter=userName%20eq%20%22bjensen@example.com%22",
+											"protocol": "http",
+											"host": [
+												"api",
+												"TENANT_NAME",
+												"forgeblocks",
+												"com"
+											],
+											"path": [
+												"users"
+											],
+											"query": [
+												{
+													"key": "filter",
+													"value": "userName%20eq%20%22bjensen@example.com%22"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-DNS-Prefetch-Control",
+											"value": "off"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "SAMEORIGIN"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=15552000; includeSubDomains"
+										},
+										{
+											"key": "X-Download-Options",
+											"value": "noopen"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "X-XSS-Protection",
+											"value": "1; mode=block"
+										},
+										{
+											"key": "Access-Control-Allow-Origin",
+											"value": "*"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json; charset=utf-8"
+										},
+										{
+											"key": "Content-Length",
+											"value": "1406"
+										},
+										{
+											"key": "ETag",
+											"value": "W/\"57e-ucPi5c43W0iNWymLLe5KJNDfcSY\""
+										},
+										{
+											"key": "Date",
+											"value": "Sun, 14 Apr 2019 00:35:43 GMT"
+										},
+										{
+											"key": "Via",
+											"value": "1.1 google"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"schemas\": [\n        \"urn:ietf:params:scim:api:messages:2.0:ListResponse\"\n    ],\n    \"resources\": [\n        {\n            \"accountStatus\": \"Active\",\n            \"addresses\": [\n                {\n                    \"type\": \"home\",\n                    \"streetAddress\": \"2800 E Observatory Rd\",\n                    \"locality\": \"Los Angeles\",\n                    \"region\": \"CA\",\n                    \"postalCode\": \"90027\",\n                    \"country\": \"US\",\n                    \"formatted\": \"2800 E Observatory Rd\\nLos Angeles, CA 90027 USA\"\n                },\n                {\n                    \"type\": \"work\",\n                    \"streetAddress\": \"6926 Hollywood Blvd\",\n                    \"locality\": \"Hollywood\",\n                    \"region\": \"CA\",\n                    \"postalCode\": \"90028\",\n                    \"country\": \"US\",\n                    \"formatted\": \"6925 Hollywood Blvd\\nHollywood, CA 90028 USA\",\n                    \"primary\": true\n                }\n            ],\n            \"displayName\": \"Babs Jensen\",\n            \"emails\": [\n                {\n                    \"value\": \"bjensen@example.com\",\n                    \"type\": \"work\",\n                    \"primary\": true,\n                    \"verified\": false\n                },\n                {\n                    \"value\": \"babs@jensen.org\",\n                    \"type\": \"home\",\n                    \"verified\": false\n                }\n            ],\n            \"id\": \"9ba4d69f-d48e-4f82-b5a8-29047aa5f881\",\n            \"ims\": [],\n            \"locale\": \"en-US\",\n            \"name\": {\n                \"formatted\": \"Ms. Barbara J Jensen, III\",\n                \"familyName\": \"Jensen\",\n                \"givenName\": \"Barbara\",\n                \"middleName\": \"Jane\",\n                \"honorificPrefix\": \"Ms.\",\n                \"honorificSuffix\": \"III\"\n            },\n            \"nickName\": \"Babs\",\n            \"phoneNumbers\": [\n                {\n                    \"value\": \"555-555-5555\",\n                    \"type\": \"work\"\n                },\n                {\n                    \"value\": \"555-555-4444\",\n                    \"type\": \"mobile\"\n                }\n            ],\n            \"preferences\": {},\n            \"preferredLanguage\": \"en-US\",\n            \"profileUrl\": \"https://login.example.com/bjensen\",\n            \"timezone\": \"America/Los_Angeles\",\n            \"title\": \"Master Carpenter\",\n            \"userName\": \"bjensen@example.com\",\n            \"userType\": \"Customer\",\n            \"x509Certificates\": [],\n            \"meta\": {\n                \"created\": \"2019-04-09T20:47:07.701Z\",\n                \"lastModified\": \"2019-04-14T00:34:47.902Z\"\n            }\n        }\n    ],\n    \"totalResults\": 1,\n    \"itemsPerPage\": 1,\n    \"startIndex\": 0\n}"
+								}
+							]
+						},
+						{
 							"name": "Get user",
 							"request": {
 								"auth": {
@@ -4060,10 +4216,6 @@
 								},
 								"method": "GET",
 								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{accessToken}}"
-									},
 									{
 										"key": "Content-Type",
 										"value": "application/json",

--- a/ForgeRock Environment Vars 0.3.postman_environment.json
+++ b/ForgeRock Environment Vars 0.3.postman_environment.json
@@ -164,9 +164,33 @@
 				"type": "text/plain"
 			},
 			"enabled": true
+		},
+		{
+			"key": "parameter",
+			"value": "filter",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "userProperty",
+			"value": "userName",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "comparator",
+			"value": "eq",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "value",
+			"value": "bjensen@example.com",
+			"description": "",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2019-04-02T23:09:35.164Z",
+	"_postman_exported_at": "2019-04-23T23:06:44.263Z",
 	"_postman_exported_using": "Postman/7.0.6"
 }


### PR DESCRIPTION
At least for now, I'm limiting this to one search option. You can see this depicted in the following [draft Postman doc](https://cloud-forgerock.postman.co/collections/2524838-b43ab656-9ce4-43c6-bbf9-0f1e8e252804?workspace=e2de3cad-8146-4cdc-b9dc-b21eaf1e985d#5c8142f8-88fc-4031-97f6-81f95f8c35dc)

(If the link doesn't get you there, it's 

Management APIs > Users > GET Get users with conditions, as shown here:

![Screenshot from 2019-04-14 21-26-21](https://user-images.githubusercontent.com/3287976/56107673-69203a00-5efc-11e9-8a18-41663be59665.png)

As the details are currently described in [this section](https://developer-cloud.forgerock.com/apis/apis-filtering/), I've left out the same details from the Postman Pro docs. (I do plan to move this to the [API Reference](https://developer-cloud.forgerock.com/api-reference/password-policies/) section, per [FRAAS-305](https://bugster.forgerock.org/jira/browse/FRAAS-305).