### PR TITLE
[FRAAS-463] Near comprehensive rewrite

### DIFF
--- a/ForgeRock Cloud APIs.postman_collection.json
+++ b/ForgeRock Cloud APIs.postman_collection.json
@@ -1,1833 +1,1624 @@
 {
 	"info": {
-		"_postman_id": "b43ab656-9ce4-43c6-bbf9-0f1e8e252804",
-		"name": "ForgeRock Cloud APIs (Apr 2019.2)",
-		"description": "The ForgeRock Identity Cloud includes two sets of APIs:\n\n* Authentication APIs: Allows you to authenticate users into your apps.\n\n* Management APIs: Supports management of objects such as users.\n\nNote: Many of the REST calls in this collection require that you have set up a web app, using the steps described in our documentation on <a href=\"https://developer-cloud.forgerock.com/sdks/nodejs/\" target=\"_blank\">SDKs: Web App (Node.js SDK)</a>.\n\nSome of these REST calls include scopes, which specify access rights as described in our documentation on <a href=\"https://developer-cloud.forgerock.com/reference/scopes/\" target=\"_blank\">scopes</a>. Use that guidance to set up the scopes property in your Postman collection.\n\nThe scopes that you specify in REST calls should be included in relevant apps. When you create an app in the UI, you can identify and update these scopes under the \"API Scopes\" tab. \n\n<p>\n\nThis collection is set up with the following environment: ForgeRock Environment Vars 0.3. You can use the environment to pre-populate your REST calls. For more information, see the following section on <a href=\"https://developer-cloud.forgerock.com/apis/apis/\" target=\"_blank\">REST APIs</a>.\n\nSome REST calls are configured to \"pre-populate\" others; for example, when you run the POST Get Web App Token - Password Grant call, the output pre-populates values for userAccessToken, refreshToken, and userIdToken.\n\nAll example responses are based on cURL.",
+		"_postman_id": "d7101d4d-727b-4243-897b-f604462428b8",
+		"name": "ForgeRock Cloud APIs (June 2019)",
+		"description": "The ForgeRock Identity Cloud includes two sets of APIs:\n\n* Management APIs: Supports management of objects such as users.\n\n* Authentication APIs: Allows you to authenticate users into your apps.\n\nSome of these REST calls include scopes, which specify access rights as described in our documentation on <a href=\"https://developer-cloud.forgerock.com/reference/scopes/\" target=\"_blank\">scopes</a>. Use that guidance to set up the scopes property in your Postman collection.\n\nThe scopes that you specify in REST calls should be included in relevant apps. When you create an app in the UI, you can identify and update these scopes under the \"API Scopes\" tab. \n\n<p>\n\nThis collection is set up with the following environment: ForgeRock Environment Vars 0.4. You can use the environment to pre-populate your REST calls. For more information, see the following section on <a href=\"https://developer-cloud.forgerock.com/apis/apis/\" target=\"_blank\">REST APIs</a>.\n\nSome REST calls are configured to \"pre-populate\" others; for example, when you run the POST Get Web App Token - Password Grant call, the output pre-populates values for userAccessToken, refreshToken, and userIdToken. Other REST calls are configured to use these values to simplify your work.\n\nAll example commands and responses are based on cURL.\n\n<p>\n\nTo run these REST calls, you need two things:\n\n* The tenant name of your deployment. You can find it in the URL you used to sign in to the admin console: https://ui-<tenant name>.forgeblocks.com/.\n* The access token you get when you sign into the admin console, available from the _developer_ options for your browser. For more information, see the following quick start page: <a href=\"https://developer-cloud.forgerock.com/quickstarts/web-app/\" target=\"_blank\">Web App</a>.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
-		{
-			"name": "Authentication APIs",
-			"item": [
-				{
-					"name": "Get Web App Token - Password Grant",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "f298b48d-fb9c-4c0a-a0c5-cc77ffd1a7dc",
-								"exec": [
-									"var jsonData = JSON.parse(responseBody);",
-									"postman.setEnvironmentVariable(\"userAccessToken\", jsonData.access_token);",
-									"postman.setEnvironmentVariable(\"refreshToken\", jsonData.refresh_token);",
-									"postman.setEnvironmentVariable(\"userIdToken\", jsonData.id_token);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "{{client_secret}}",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "{{client_id}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
-								"value": "application/x-www-form-urlencoded"
-							}
-						],
-						"body": {
-							"mode": "urlencoded",
-							"urlencoded": [
-								{
-									"key": "grant_type",
-									"value": "password",
-									"description": "As allowed by your web app",
-									"type": "text"
-								},
-								{
-									"key": "username",
-									"value": "{{userName}}",
-									"type": "text"
-								},
-								{
-									"key": "password",
-									"value": "{{userPassword}}",
-									"type": "text"
-								},
-								{
-									"key": "scope",
-									"value": "{{scopes}}",
-									"description": ". As defined for your app.",
-									"type": "text"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{oauth2Url}}/access_token",
-							"host": [
-								"{{oauth2Url}}"
-							],
-							"path": [
-								"access_token"
-							]
-						},
-						"description": "Requires credentials for an existing user. This call sets up a base64-encoded value for the web app via `Basic Auth` under authentication, using the Client ID and Client Secret for the web app.\n\nReturns tokens specific to a user:\n* access_token\n* refresh_token\n* id_token\n\nYou'll need these tokens for other REST calls for the specific user. In your Postman app, under the Test tab for this REST call, you'll see code that captures these tokens as input for corresponding environment variables. \n\nWhen you include scopes, make sure they correspond to active scopes for your app."
-					},
-					"response": [
-						{
-							"name": "Get Web App Token - Password Grant",
-							"originalRequest": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/x-www-form-urlencoded"
-									},
-									{
-										"key": "Authorization",
-										"value": "Basic {{BASE_64_ENCODED_STRING}}",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "urlencoded",
-									"urlencoded": [
-										{
-											"key": "grant_type",
-											"value": "password",
-											"type": "text"
-										},
-										{
-											"key": "username",
-											"value": "{{userName}}",
-											"type": "text"
-										},
-										{
-											"key": "password",
-											"value": "{{userPassword}}",
-											"type": "text"
-										},
-										{
-											"key": "scope",
-											"value": "me.read me.update me.update-password password-policy.read user.reset-password user.recover-username user.create user.read openid profile",
-											"description": ". ",
-											"type": "text"
-										}
-									]
-								},
-								"url": {
-									"raw": "{{oauth2Url}}/access_token",
-									"host": [
-										"{{oauth2Url}}"
-									],
-									"path": [
-										"access_token"
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "X-Frame-Options",
-									"value": "SAMEORIGIN"
-								},
-								{
-									"key": "Pragma",
-									"value": "no-cache"
-								},
-								{
-									"key": "Cache-Control",
-									"value": "no-store"
-								},
-								{
-									"key": "Date",
-									"value": "Thu, 07 Mar 2019 15:08:14 GMT"
-								},
-								{
-									"key": "Accept-Ranges",
-									"value": "bytes"
-								},
-								{
-									"key": "Vary",
-									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
-								},
-								{
-									"key": "Content-Type",
-									"value": "application/json"
-								},
-								{
-									"key": "Transfer-Encoding",
-									"value": "chunked"
-								},
-								{
-									"key": "Via",
-									"value": "1.1 google"
-								},
-								{
-									"key": "Alt-Svc",
-									"value": "clear"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"access_token\": \"{{userAccessToken}}\",\n    \"refresh_token\": \"{{userRefreshToken}}\",\n    \"scope\": \"openid me.update profile user.recover-username user.read me.read user.create password-policy.read me.update-password user.reset-password\",\n    \"id_token\": \"{{userIdToken}}\",\n    \"token_type\": \"Bearer\",\n    \"expires_in\": 3599\n}"
-						}
-					]
-				},
-				{
-					"name": "UserInfo",
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{userAccessToken}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
-								"value": "application/x-www-form-urlencoded"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{oauth2Url}}/userinfo",
-							"host": [
-								"{{oauth2Url}}"
-							],
-							"path": [
-								"userinfo"
-							]
-						},
-						"description": "Returns end user info. Requires an access_token created for the specific user, set as the *Bearer* token. You can acquire a user access_token from the Get Web App Token - Password Grant REST call."
-					},
-					"response": [
-						{
-							"name": "UserInfo",
-							"originalRequest": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{userAccessToken}}"
-									},
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"value": "application/x-www-form-urlencoded",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{oauth2Url}}/userinfo",
-									"host": [
-										"{{oauth2Url}}"
-									],
-									"path": [
-										"userinfo"
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "X-Frame-Options",
-									"value": "SAMEORIGIN"
-								},
-								{
-									"key": "Date",
-									"value": "Tue, 05 Mar 2019 15:51:43 GMT"
-								},
-								{
-									"key": "Accept-Ranges",
-									"value": "bytes"
-								},
-								{
-									"key": "Vary",
-									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
-								},
-								{
-									"key": "Content-Type",
-									"value": "application/json;charset=UTF-8"
-								},
-								{
-									"key": "Transfer-Encoding",
-									"value": "chunked"
-								},
-								{
-									"key": "Via",
-									"value": "1.1 google"
-								},
-								{
-									"key": "Alt-Svc",
-									"value": "clear"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"locale\": \"en-US\",\n    \"nickname\": \"Babs\",\n    \"profile_url\": \"https://login.example.com/bjensen\",\n    \"title\": \"Master Carpenter\",\n    \"zoneinfo\": \"America/Los_Angeles\",\n    \"sub\": \"bjensen@example.com\"\n}"
-						}
-					]
-				},
-				{
-					"name": "Tokeninfo",
-					"request": {
-						"auth": {
-							"type": "noauth"
-						},
-						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{oauth2Url}}/tokeninfo?access_token={{userAccessToken}}",
-							"host": [
-								"{{oauth2Url}}"
-							],
-							"path": [
-								"tokeninfo"
-							],
-							"query": [
-								{
-									"key": "access_token",
-									"value": "{{userAccessToken}}"
-								}
-							]
-						},
-						"description": "Validates a user ID token for debugging. Requires an access_token created for the specific user, set as the *Bearer* token. You can acquire a user access_token from the Get Web App Token - Password Grant REST call."
-					},
-					"response": [
-						{
-							"name": "Tokeninfo",
-							"originalRequest": {
-								"method": "GET",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{oauth2Url}}/tokeninfo?access_token={{userAccessToken}}",
-									"host": [
-										"{{oauth2Url}}"
-									],
-									"path": [
-										"tokeninfo"
-									],
-									"query": [
-										{
-											"key": "access_token",
-											"value": "{{userAccessToken}}"
-										}
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "X-Frame-Options",
-									"value": "SAMEORIGIN"
-								},
-								{
-									"key": "Cache-Control",
-									"value": "no-cache, no-store"
-								},
-								{
-									"key": "Date",
-									"value": "Thu, 07 Mar 2019 15:11:33 GMT"
-								},
-								{
-									"key": "Accept-Ranges",
-									"value": "bytes"
-								},
-								{
-									"key": "Vary",
-									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
-								},
-								{
-									"key": "Content-Type",
-									"value": "application/json"
-								},
-								{
-									"key": "Transfer-Encoding",
-									"value": "chunked"
-								},
-								{
-									"key": "Via",
-									"value": "1.1 google"
-								},
-								{
-									"key": "Alt-Svc",
-									"value": "clear"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"sub\": \"bjensen@example.com\",\n    \"auth_level\": 0,\n    \"auditTrackingId\": \"3d9f9676-faca-442c-b007-f6a2ea8b67fd-3646\",\n    \"me.update\": \"\",\n    \"iss\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2\",\n    \"tokenName\": \"access_token\",\n    \"token_type\": \"Bearer\",\n    \"user.recover-username\": \"\",\n    \"user.read\": \"\",\n    \"password-policy.read\": \"\",\n    \"grant_type\": \"password\",\n    \"scope\": [\n        \"openid\",\n        \"me.update\",\n        \"profile\",\n        \"user.recover-username\",\n        \"user.read\",\n        \"me.read\",\n        \"user.create\",\n        \"password-policy.read\",\n        \"me.update-password\",\n        \"user.reset-password\"\n    ],\n    \"auth_time\": 1551971292,\n    \"me.update-password\": \"\",\n    \"exp\": 1551974893,\n    \"iat\": 1551971293,\n    \"expires_in\": 3600,\n    \"jti\": \"PWL_Al8ylGiL_L5liNSxJaDIb_4\",\n    \"cts\": \"OAUTH2_STATELESS_GRANT\",\n    \"openid\": \"\",\n    \"profile\": \"\",\n    \"authGrantId\": \"cfQfXBMdSs91iktKG6Uo21i7-7Y\",\n    \"access_token\": \"{{userAccessToken}}\",\n    \"aud\": \"750e67f55c7693f17cae0f8cdae4b9c8\",\n    \"me.read\": \"\",\n    \"user.create\": \"\",\n    \"nbf\": 1551971293,\n    \"realm\": \"/\",\n    \"user.reset-password\": \"\"\n}"
-						}
-					]
-				},
-				{
-					"name": "Check session",
-					"request": {
-						"auth": {
-							"type": "noauth"
-						},
-						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{oauth2Url}}/connect/checkSession?id_token={{userIdToken}}",
-							"host": [
-								"{{oauth2Url}}"
-							],
-							"path": [
-								"connect",
-								"checkSession"
-							],
-							"query": [
-								{
-									"key": "id_token",
-									"value": "{{userIdToken}}"
-								}
-							]
-						},
-						"description": "Check the session state of the user with the id_token. Allows clients to receive notifications. You can get the id_token from the Get Web App Token - Password Grant REST call."
-					},
-					"response": [
-						{
-							"name": "Check session",
-							"originalRequest": {
-								"method": "GET",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{oauth2Url}}/connect/checkSession?id_token={{userIdToken}}",
-									"host": [
-										"{{oauth2Url}}"
-									],
-									"path": [
-										"connect",
-										"checkSession"
-									],
-									"query": [
-										{
-											"key": "id_token",
-											"value": "{{userIdToken}}"
-										}
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "Accept-Ranges",
-									"value": "bytes",
-									"name": "Accept-Ranges",
-									"description": "Content-Types that are acceptable"
-								},
-								{
-									"key": "Alt-Svc",
-									"value": "clear",
-									"name": "Alt-Svc",
-									"description": "Custom header"
-								},
-								{
-									"key": "Content-Type",
-									"value": "text/html;charset=UTF-8",
-									"name": "Content-Type",
-									"description": "The mime type of this content"
-								},
-								{
-									"key": "Date",
-									"value": "Fri, 05 Oct 2018 15:04:06 GMT",
-									"name": "Date",
-									"description": "The date and time that the message was sent"
-								},
-								{
-									"key": "Transfer-Encoding",
-									"value": "chunked",
-									"name": "Transfer-Encoding",
-									"description": "The form of encoding used to safely transfer the entity to the user. Currently defined methods are: chunked, compress, deflate, gzip, identity."
-								},
-								{
-									"key": "Vary",
-									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept",
-									"name": "Vary",
-									"description": "Tells downstream proxies how to match future request headers to decide whether the cached response can be used rather than requesting a fresh one from the origin server."
-								},
-								{
-									"key": "Via",
-									"value": "1.1 google",
-									"name": "Via",
-									"description": "Informs the client of proxies through which the response was sent."
-								},
-								{
-									"key": "X-Frame-Options",
-									"value": "SAMEORIGIN",
-									"name": "X-Frame-Options",
-									"description": "Clickjacking protection: \"deny\" - no rendering within a frame, \"sameorigin\" - no rendering if origin mismatch"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"at_hash\": \"UF3q_638GcngsEh6B5lglA\",\n    \"sub\": \"demouser\",\n    \"auditTrackingId\": \"a0deb639-832d-4c97-a4d2-4440c2727b02-7851\",\n    \"iss\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2\",\n    \"tokenName\": \"id_token\",\n    \"aud\": \"18c0d0bf98973a2660364198d45f927d\",\n    \"c_hash\": \"gQkCnvaICC0kT4A1wXyukA\",\n    \"acr\": \"0\",\n    \"org.forgerock.openidconnect.ops\": \"MYRjCWkJ0G4gBWDPEIfiVjtrLp4\",\n    \"azp\": \"18c0d0bf98973a2660364198d45f927d\",\n    \"auth_time\": 1551712897,\n    \"realm\": \"/\",\n    \"exp\": 1551716498,\n    \"tokenType\": \"JWTToken\",\n    \"iat\": 1551712898,\n    \"forgerock\": {\n        \"sig\": \"2+fDlj)0>F2y?aL9m5h:S@&]!T[=)KE#LA}.ik.c\"\n    }\n}"
-						}
-					]
-				},
-				{
-					"name": "End session",
-					"request": {
-						"auth": {
-							"type": "noauth"
-						},
-						"method": "GET",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{oauth2Url}}/connect/endSession?id_token_hint={{userIdToken}}&post_logout_redirect_uri={{yourAppUrl}}",
-							"host": [
-								"{{oauth2Url}}"
-							],
-							"path": [
-								"connect",
-								"endSession"
-							],
-							"query": [
-								{
-									"key": "id_token_hint",
-									"value": "{{userIdToken}}"
-								},
-								{
-									"key": "post_logout_redirect_uri",
-									"value": "{{yourAppUrl}}"
-								}
-							]
-						},
-						"description": "End the current session. Requires the id_token created for the user, which is set to id_token_hint. You can get this value from the POST GET Web App Token - Password Grant REST call."
-					},
-					"response": []
-				},
-				{
-					"name": "Introspect",
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "{{client_secret}}",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "{{client_id}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{oauth2Url}}/introspect?token={{userAccessToken}}",
-							"host": [
-								"{{oauth2Url}}"
-							],
-							"path": [
-								"introspect"
-							],
-							"query": [
-								{
-									"key": "token",
-									"value": "{{userAccessToken}}"
-								}
-							]
-						},
-						"description": "Returns the content of an access token, including scopes. Requires the Client ID and Client Secret for an existing web app."
-					},
-					"response": [
-						{
-							"name": "Introspect",
-							"originalRequest": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/x-www-form-urlencoded"
-									},
-									{
-										"description": "Base 64 Encoded version of Basic {{clientId}}:{{clientSecret}}",
-										"key": "Authorization",
-										"value": "Basic {{BASE_64_ENCODED_STRING}}",
-										"warning": "This is a duplicate header and will be overridden by the Authorization header generated by Postman.",
-										"disabled": true
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{oauth2Url}}/introspect?token={{userAccessToken}}",
-									"host": [
-										"{{oauth2Url}}"
-									],
-									"path": [
-										"introspect"
-									],
-									"query": [
-										{
-											"key": "token",
-											"value": "{{userAccessToken}}"
-										}
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "X-Frame-Options",
-									"value": "SAMEORIGIN"
-								},
-								{
-									"key": "Date",
-									"value": "Thu, 07 Mar 2019 15:16:13 GMT"
-								},
-								{
-									"key": "Accept-Ranges",
-									"value": "bytes"
-								},
-								{
-									"key": "Vary",
-									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
-								},
-								{
-									"key": "Content-Type",
-									"value": "application/json;charset=UTF-8"
-								},
-								{
-									"key": "Transfer-Encoding",
-									"value": "chunked"
-								},
-								{
-									"key": "Via",
-									"value": "1.1 google"
-								},
-								{
-									"key": "Alt-Svc",
-									"value": "clear"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"active\": true,\n    \"scope\": \"user.read me.read user.create password-policy.read openid me.update profile me.update-password user.recover-username user.reset-password\",\n    \"client_id\": \"750e67f55c7693f17cae0f8cdae4b9c8\",\n    \"user_id\": \"bjensen@example.com\",\n    \"token_type\": \"Bearer\",\n    \"exp\": 1551974893,\n    \"sub\": \"bjensen@example.com\",\n    \"iss\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2\",\n    \"auth_level\": 0\n}"
-						}
-					]
-				},
-				{
-					"name": "Get Refresh Token",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "87002a5c-5df5-42a2-ac89-6a717f7a3c16",
-								"exec": [
-									"var jsonData = JSON.parse(responseBody);",
-									"postman.setEnvironmentVariable(\"userAccessToken\", jsonData.access_token);",
-									"postman.setEnvironmentVariable(\"refreshToken\", jsonData.refresh_token);",
-									"postman.setEnvironmentVariable(\"userIdToken\", jsonData.id_token);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "{{client_secret}}",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "{{client_id}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded"
-							}
-						],
-						"body": {
-							"mode": "urlencoded",
-							"urlencoded": [
-								{
-									"key": "grant_type",
-									"value": "refresh_token",
-									"type": "text"
-								},
-								{
-									"key": "refresh_token",
-									"value": "{{refreshToken}}",
-									"type": "text"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{oauth2Url}}/access_token",
-							"host": [
-								"{{oauth2Url}}"
-							],
-							"path": [
-								"access_token"
-							]
-						},
-						"description": "A refresh_token can be used to obtain a new access_token. The new access_token may include the same or a more narrow set of scopes."
-					},
-					"response": [
-						{
-							"name": "Get Refresh Token",
-							"originalRequest": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/x-www-form-urlencoded"
-									},
-									{
-										"description": "Base64-Encoded version of Basic{{webAppClientId}}:{{webAppSecret}})",
-										"key": "Authorization",
-										"type": "text",
-										"value": "Basic {{BASE_64_ENCODED_STRING}}"
-									}
-								],
-								"body": {
-									"mode": "urlencoded",
-									"urlencoded": [
-										{
-											"key": "grant_type",
-											"value": "refresh_token",
-											"type": "text"
-										},
-										{
-											"key": "refresh_token",
-											"value": "{{refreshToken}}",
-											"type": "text"
-										}
-									]
-								},
-								"url": {
-									"raw": "{{oauth2Url}}/access_token",
-									"host": [
-										"{{oauth2Url}}"
-									],
-									"path": [
-										"access_token"
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "X-Frame-Options",
-									"value": "SAMEORIGIN"
-								},
-								{
-									"key": "Pragma",
-									"value": "no-cache"
-								},
-								{
-									"key": "Cache-Control",
-									"value": "no-store"
-								},
-								{
-									"key": "Date",
-									"value": "Wed, 06 Mar 2019 17:14:40 GMT"
-								},
-								{
-									"key": "Accept-Ranges",
-									"value": "bytes"
-								},
-								{
-									"key": "Vary",
-									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
-								},
-								{
-									"key": "Content-Type",
-									"value": "application/json"
-								},
-								{
-									"key": "Transfer-Encoding",
-									"value": "chunked"
-								},
-								{
-									"key": "Via",
-									"value": "1.1 google"
-								},
-								{
-									"key": "Alt-Svc",
-									"value": "clear"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"access_token\": \"{{accessToken}}\",\n    \"refresh_token\": \"{{refreshToken}}\",\n    \"scope\": \"user.read me.read password-policy.read openid profile user.recover-username user.reset-password\",\n    \"id_token\": \"{{idToken}}\",\n    \"token_type\": \"Bearer\",\n    \"expires_in\": 3599\n}"
-						}
-					]
-				},
-				{
-					"name": "Revoke",
-					"request": {
-						"auth": {
-							"type": "noauth"
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded"
-							}
-						],
-						"body": {
-							"mode": "urlencoded",
-							"urlencoded": [
-								{
-									"key": "token",
-									"value": "{{userAccessToken}}",
-									"type": "text"
-								},
-								{
-									"key": "client_id",
-									"value": "{{client_id}}",
-									"type": "text"
-								},
-								{
-									"key": "client_secret",
-									"value": "{{client_secret}}",
-									"type": "text"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{oauth2Url}}/token/revoke",
-							"host": [
-								"{{oauth2Url}}"
-							],
-							"path": [
-								"token",
-								"revoke"
-							]
-						},
-						"description": "Revoke an access_token for an app. Requires an access_token created for the app, set as the *Bearer* token. You can acquire an app access_token from the Get Web App Token - Auth Code Grant REST call."
-					},
-					"response": [
-						{
-							"name": "Revoke",
-							"originalRequest": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/x-www-form-urlencoded"
-									}
-								],
-								"body": {
-									"mode": "urlencoded",
-									"urlencoded": [
-										{
-											"key": "token",
-											"value": "{{accessToken}}",
-											"type": "text"
-										},
-										{
-											"key": "client_id",
-											"value": "{{clientId}}",
-											"type": "text"
-										},
-										{
-											"key": "client_secret",
-											"value": "{{clientSecret}}",
-											"type": "text"
-										}
-									]
-								},
-								"url": {
-									"raw": "{{oauth2Url}}/token/revoke",
-									"host": [
-										"{{oauth2Url}}"
-									],
-									"path": [
-										"token",
-										"revoke"
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "Text",
-							"header": [],
-							"cookie": [],
-							"body": "{}"
-						}
-					]
-				},
-				{
-					"name": "Authorize",
-					"request": {
-						"auth": {
-							"type": "noauth"
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"name": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{oauth2Url}}/authorize?client_id={{client_id}}&response_type=code&redirect_uri={{yourAppUrl}}&scope={{scopes}}",
-							"host": [
-								"{{oauth2Url}}"
-							],
-							"path": [
-								"authorize"
-							],
-							"query": [
-								{
-									"key": "client_id",
-									"value": "{{client_id}}"
-								},
-								{
-									"key": "response_type",
-									"value": "code"
-								},
-								{
-									"key": "redirect_uri",
-									"value": "{{yourAppUrl}}",
-									"description": "Consent will redirect to this url with access_token & additional response parameters"
-								},
-								{
-									"key": "scope",
-									"value": "{{scopes}}"
-								}
-							]
-						},
-						"description": "This REST call assumes that you've set up a Web App as described in the following documentation: <a href=\"https://developer-cloud.forgerock.com/sdks/nodejs/\" target=\"_blank\">Web App (Node.js SDK)</a>.\n\nUse this call to find the authorization code grant type in the POST Get Web App Token REST calls.\n\nTo find the authorization code, you'll first need a Location URL. Run the REST call in one of the following two ways:\n* Run the REST call in the CLI in verbose mode\n* Review the REST output in the Postman console\n\n(It's OK if you get a 302 Found result. You can still get the information in one of the two ways noted.)\n\nOpen to the browser of your choice. \n* Navigate to the Location URL.  \n* Open the developer mode for your browser.\n* Navigate to your network monitor. \n* Log in as a regular user.\n* Find the entry with `callback?code`.\n* Look for the parameters for that entry.\n* Find and copy the `code` entry associated with the `query string`. That is your authorization code. \n\nYou'll need that `code` in the **Get Web App Token** REST calls."
-					},
-					"response": [
-						{
-							"name": "Authorize",
-							"originalRequest": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/x-www-form-urlencoded"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{oauth2Url}}/authorize?client_id={{webAppClientId}}&response_type=code&redirect_uri=http://localhost:9080/callback&scope=user.read openid",
-									"host": [
-										"{{oauth2Url}}"
-									],
-									"path": [
-										"authorize"
-									],
-									"query": [
-										{
-											"key": "client_id",
-											"value": "{{webAppClientId}}"
-										},
-										{
-											"key": "response_type",
-											"value": "code"
-										},
-										{
-											"key": "redirect_uri",
-											"value": "http://localhost:9080/callback",
-											"description": "Consent redirects to this url with access_token & additional response params"
-										},
-										{
-											"key": "scope",
-											"value": "user.read openid"
-										}
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "html",
-							"header": [
-								{
-									"key": "X-Powered-By",
-									"value": "Express"
-								},
-								{
-									"key": "Content-Type",
-									"value": "text/html; charset=utf-8"
-								},
-								{
-									"key": "Content-Length",
-									"value": "3046"
-								},
-								{
-									"key": "ETag",
-									"value": "W/\"be6-HS7bdcybfnbj2k+JyRLBMB8kkZE\""
-								},
-								{
-									"key": "Date",
-									"value": "Fri, 01 Mar 2019 01:01:40 GMT"
-								},
-								{
-									"key": "Via",
-									"value": "1.1 google"
-								},
-								{
-									"key": "Alt-Svc",
-									"value": "clear"
-								}
-							],
-							"cookie": [],
-							"body": "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge,chrome=1\"><title>ForgeRock</title><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/apple-touch-icon.png\"><link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"/favicon-32x32.png\"><link rel=\"icon\" type=\"image/png\" sizes=\"16x16\" href=\"/favicon-16x16.png\"><link rel=\"manifest\" href=\"/site.webmanifest\"><link rel=\"mask-icon\" href=\"/safari-pinned-tab.svg\" color=\"#5bbad5\"><link rel=\"stylesheet\" type=\"text/css\" href=\"/css/bootstrap-3.3.5-custom.css?v=5.5.1\"><link rel=\"stylesheet\" type=\"text/css\" href=\"/css/structure.css?v=5.5.1\"><link rel=\"stylesheet\" type=\"text/css\" href=\"/css/theme.css?v=5.5.1\"><meta name=\"msapplication-TileColor\" content=\"#00a300\"><meta name=\"theme-color\" content=\"#ffffff\"><link href=\"https://fonts.googleapis.com/css?family=Roboto:400,500\" rel=\"stylesheet\"></head><body><div class=\"container\"><div class=\"row\"><div class=\"col-sm-2 col-md-3 col-lg-3\">&nbsp;</div><div class=\"col-sm-8 col-md-6 col-lg-6\"><link rel=\"stylesheet\" type=\"text/css\" href=\"https://ui-{{tenantName}}.forgeblocks.com/css/hosted.css\"><div id=\"login-page\"><header><img class=\"logo\" src=\"https://ui-{{tenantName}}.forgeblocks.com/img/logo-forgerock.png\" alt=\"logo\"><h1>Sign In</h1></header><form method=\"POST\"><fieldset><label>Username</label><input name=\"userName\" class=\"input-text fullwidth\" type=\"text\" />\n    </fieldset><fieldset><label>Password</label><input name=\"password\" class=\"input-text fullwidth\" type=\"password\" />\n    </fieldset><button id=\"login\" type=\"submit\">Login</button></form><footer><p><span>New here? <a id=\"register\" href=\"./register?goto&#x3D;https%3A%2F%2Fopenam-{{tenantName}}.forgeblocks.com%2Foauth2%2Fauthorize%3Fclient_id%3Da974430b2d66967b34c937b892f4a63e%26response_type%3Dcode%26redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A9080%252Fcallback%26scope%3Duser.read%2520openid&amp;realm&#x3D;/\">Register an account</a></span></p><p><span>Forgot password? <a id=\"forgot-password\" href=\"./forgot-password?goto&#x3D;https%3A%2F%2Fopenam-{{tenantName}}.forgeblocks.com%2Foauth2%2Fauthorize%3Fclient_id%3Da974430b2d66967b34c937b892f4a63e%26response_type%3Dcode%26redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A9080%252Fcallback%26scope%3Duser.read%2520openid&amp;realm&#x3D;/\">Retrieve it here</a></span></p><p><span>Forgot username? <a id=\"recover-username\" href=\"./recover-username?goto&#x3D;https%3A%2F%2Fopenam-{{tenantName}}.forgeblocks.com%2Foauth2%2Fauthorize%3Fclient_id%3Da974430b2d66967b34c937b892f4a63e%26response_type%3Dcode%26redirect_uri%3Dhttp%253A%252F%252Flocalhost%253A9080%252Fcallback%26scope%3Duser.read%2520openid&amp;realm&#x3D;/\">Retrieve it here</a></span></p>\n  </footer></div>\n      </div><div class=\"col-sm-2 col-md-6 col-lg-3\">&nbsp;</div></div>\n  </div></body>\n\n</html>"
-						}
-					]
-				},
-				{
-					"name": "Authorize (Without Browser)",
-					"request": {
-						"auth": {
-							"type": "noauth"
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Cookie",
-								"type": "text",
-								"value": "iPlanetDirectoryPro={{iPlanetDirectoryPro}}"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{oauth2Url}}/authorize?client_id={{client_id}}&response_type=code&redirect_uri={{yourAppUrl}}callback/non-hosted&csrf={{iPlanetDirectoryPro}}&scope=profile&decision=allow",
-							"host": [
-								"{{oauth2Url}}"
-							],
-							"path": [
-								"authorize"
-							],
-							"query": [
-								{
-									"key": "client_id",
-									"value": "{{client_id}}",
-									"description": "For your app"
-								},
-								{
-									"key": "response_type",
-									"value": "code",
-									"description": "Standard flow"
-								},
-								{
-									"key": "redirect_uri",
-									"value": "{{yourAppUrl}}callback/non-hosted",
-									"description": "Substitute the URL for your app"
-								},
-								{
-									"key": "csrf",
-									"value": "{{iPlanetDirectoryPro}}",
-									"description": "Set to the value of the iPlanetDirectoryPro token"
-								},
-								{
-									"key": "scope",
-									"value": "profile"
-								},
-								{
-									"key": "decision",
-									"value": "allow"
-								}
-							]
-						},
-						"description": "Requires an iPlanetDirectoryPro cookie; also used as the value of `csrf`."
-					},
-					"response": [
-						{
-							"name": "Authorize (Without Browser)",
-							"originalRequest": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Cookie",
-										"value": "iPlanetDirectoryPro={{userIdToken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{oauth2Url}}/authorize?client_id={{client_id}}&response_type=code&redirect_uri=http://localhost:9080/callback/non-hosted&csrf={{userIdToken}}&scope=profile&decision=allow",
-									"host": [
-										"{{oauth2Url}}"
-									],
-									"path": [
-										"authorize"
-									],
-									"query": [
-										{
-											"key": "client_id",
-											"value": "{{client_id}}"
-										},
-										{
-											"key": "response_type",
-											"value": "code"
-										},
-										{
-											"key": "redirect_uri",
-											"value": "http://localhost:9080/callback/non-hosted"
-										},
-										{
-											"key": "csrf",
-											"value": "{{userIdToken}}"
-										},
-										{
-											"key": "scope",
-											"value": "profile"
-										},
-										{
-											"key": "decision",
-											"value": "allow"
-										}
-									]
-								}
-							},
-							"status": "Bad Request",
-							"code": 400,
-							"_postman_previewlanguage": "html",
-							"header": [
-								{
-									"key": "X-Frame-Options",
-									"value": "SAMEORIGIN"
-								},
-								{
-									"key": "Pragma",
-									"value": "no-cache"
-								},
-								{
-									"key": "Cache-Control",
-									"value": "no-store"
-								},
-								{
-									"key": "Date",
-									"value": "Thu, 28 Feb 2019 19:25:31 GMT"
-								},
-								{
-									"key": "Accept-Ranges",
-									"value": "bytes"
-								},
-								{
-									"key": "Vary",
-									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
-								},
-								{
-									"key": "Content-Type",
-									"value": "text/html;charset=UTF-8"
-								},
-								{
-									"key": "Transfer-Encoding",
-									"value": "chunked"
-								},
-								{
-									"key": "Via",
-									"value": "1.1 google"
-								},
-								{
-									"key": "Alt-Svc",
-									"value": "clear"
-								}
-							],
-							"cookie": [],
-							"body": "<!DOCTYPE html>\n<!--\n  ~ DO NOT REMOVE COPYRIGHT NOTICES OR THIS HEADER.\n  ~\n  ~ Copyright 2012-2018 ForgeRock AS.\n  ~\n  ~ The contents of this file are subject to the terms\n  ~ of the Common Development and Distribution License\n  ~ (the License). You may not use this file except in\n  ~ compliance with the License.\n  ~\n  ~ You can obtain a copy of the License at\n  ~ http://forgerock.org/license/CDDLv1.0.html\n  ~ See the License for the specific language governing\n  ~ permission and limitations under the License.\n  ~\n  ~ When distributing Covered Code, include this CDDL\n  ~ Header Notice in each file and include the License file\n  ~ at http://forgerock.org/license/CDDLv1.0.html\n  ~ If applicable, add the following below the CDDL Header,\n  ~ with the fields enclosed by brackets [] replaced by\n  ~ your own identifying information:\n  ~ \"Portions Copyrighted [year] [name of copyright owner]\"\n  ~\n  ~ Portions Copyrighted 2014 Nomura Research Institute, Ltd\n  -->\n<html lang=\"en\">\n    <head>\n        <meta charset=\"utf-8\">\n        <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">\n        <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n        <meta name=\"description\" content=\"OAuth2 Error\">\n        <title>OAuth2 Error Page</title>\n    </head>\n    <body style=\"display:none\">\n        <div id=\"wrapper\">Loading...</div>\n        <footer id=\"footer\" class=\"footer\"></footer>\n        <script type=\"text/javascript\">\n                    pageData = {\n                realm : \"\\/\",\n                baseUrl: \"https://openam-{{tenantName}}.forgeblocks.com/XUI/\",\n                error: {\n                    description: \"Client authentication failed\",\n                    message: \"invalid_client\"\n                }\n            }\n    </script>\n        <script src=\"https://openam-{{tenantName}}.forgeblocks.com/XUI/main-authorize.js\"></script>\n    </body>\n</html>"
-						}
-					]
-				},
-				{
-					"name": "Get Web App Token - Auth Code Grant (Without Browser)",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "87002a5c-5df5-42a2-ac89-6a717f7a3c16",
-								"exec": [
-									"var jsonData = JSON.parse(responseBody);",
-									"postman.setEnvironmentVariable(\"appAccessToken\", jsonData.access_token);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "{{client_secret}}",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "{{client_id}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded"
-							}
-						],
-						"body": {
-							"mode": "urlencoded",
-							"urlencoded": [
-								{
-									"key": "grant_type",
-									"value": "client_credentials",
-									"type": "text"
-								},
-								{
-									"key": "code",
-									"value": "{{authCode}}",
-									"description": "Use the code returned from REST calls on the /oauth2/authorize endpoint.",
-									"type": "text"
-								},
-								{
-									"key": "redirect_uri",
-									"value": "{{yourAppUrl}}callback/non-hosted",
-									"type": "text"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{oauth2Url}}/access_token",
-							"host": [
-								"{{oauth2Url}}"
-							],
-							"path": [
-								"access_token"
-							]
-						},
-						"description": "Used when a client such as a Java application running on a server, requires access to protected resources."
-					},
-					"response": [
-						{
-							"name": "Get Web App Token - Auth Code Grant (Without Browser)",
-							"originalRequest": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/x-www-form-urlencoded"
-									}
-								],
-								"body": {
-									"mode": "urlencoded",
-									"urlencoded": [
-										{
-											"key": "grant_type",
-											"value": "client_credentials",
-											"type": "text"
-										},
-										{
-											"key": "code",
-											"value": "{{authCode}}",
-											"description": "Use the code returned from REST calls on the /oauth2/authorize endpoint.",
-											"type": "text"
-										},
-										{
-											"key": "redirect_uri",
-											"value": "http://localhost:9080/callback/non-hosted",
-											"type": "text"
-										}
-									]
-								},
-								"url": {
-									"raw": "{{oauth2Url}}/access_token",
-									"host": [
-										"{{oauth2Url}}"
-									],
-									"path": [
-										"access_token"
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "X-Frame-Options",
-									"value": "SAMEORIGIN"
-								},
-								{
-									"key": "Pragma",
-									"value": "no-cache"
-								},
-								{
-									"key": "Cache-Control",
-									"value": "no-store"
-								},
-								{
-									"key": "Date",
-									"value": "Fri, 08 Mar 2019 17:24:09 GMT"
-								},
-								{
-									"key": "Accept-Ranges",
-									"value": "bytes"
-								},
-								{
-									"key": "Vary",
-									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
-								},
-								{
-									"key": "Content-Type",
-									"value": "application/json"
-								},
-								{
-									"key": "Transfer-Encoding",
-									"value": "chunked"
-								},
-								{
-									"key": "Via",
-									"value": "1.1 google"
-								},
-								{
-									"key": "Alt-Svc",
-									"value": "clear"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"access_token\": \"{{accessToken}}\",\n    \"scope\": \"openid\",\n    \"id_token\": \"{{idToken}}\",\n    \"token_type\": \"Bearer\",\n    \"expires_in\": 3598\n}"
-						}
-					]
-				},
-				{
-					"name": "Get Web App Token - Auth Code Grant",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "87002a5c-5df5-42a2-ac89-6a717f7a3c16",
-								"exec": [
-									"var jsonData = JSON.parse(responseBody);",
-									"postman.setEnvironmentVariable(\"appAccessToken\", jsonData.access_token);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "{{client_secret}}",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "{{client_id}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded"
-							}
-						],
-						"body": {
-							"mode": "urlencoded",
-							"urlencoded": [
-								{
-									"key": "grant_type",
-									"value": "client_credentials",
-									"type": "text"
-								},
-								{
-									"key": "code",
-									"value": "{{authCode}}",
-									"description": "Use the authorization code returned from REST calls on the /authorize endpoint.",
-									"type": "text"
-								},
-								{
-									"key": "redirect_uri",
-									"value": "{{yourAppUrl}}callback",
-									"type": "text"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{oauth2Url}}/access_token",
-							"host": [
-								"{{oauth2Url}}"
-							],
-							"path": [
-								"access_token"
-							]
-						},
-						"description": "Used when a client such as a Java application running on a server, requires access to protected resources."
-					},
-					"response": [
-						{
-							"name": "Get Web App Token - Auth Code Grant (error)",
-							"originalRequest": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/x-www-form-urlencoded"
-									}
-								],
-								"body": {
-									"mode": "urlencoded",
-									"urlencoded": [
-										{
-											"key": "grant_type",
-											"value": "client_credentials",
-											"type": "text"
-										},
-										{
-											"key": "code",
-											"value": "{{authCode}}",
-											"description": "Use the authorization code returned from REST calls on the /authorize endpoint.",
-											"type": "text"
-										},
-										{
-											"key": "redirect_uri",
-											"value": "http://localhost:9080/callback",
-											"type": "text"
-										}
-									]
-								},
-								"url": {
-									"raw": "{{oauth2Url}}/access_token",
-									"host": [
-										"{{oauth2Url}}"
-									],
-									"path": [
-										"access_token"
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "X-Frame-Options",
-									"value": "SAMEORIGIN"
-								},
-								{
-									"key": "Pragma",
-									"value": "no-cache"
-								},
-								{
-									"key": "Cache-Control",
-									"value": "no-store"
-								},
-								{
-									"key": "Date",
-									"value": "Fri, 08 Mar 2019 17:28:54 GMT"
-								},
-								{
-									"key": "Accept-Ranges",
-									"value": "bytes"
-								},
-								{
-									"key": "Vary",
-									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
-								},
-								{
-									"key": "Content-Type",
-									"value": "application/json"
-								},
-								{
-									"key": "Transfer-Encoding",
-									"value": "chunked"
-								},
-								{
-									"key": "Via",
-									"value": "1.1 google"
-								},
-								{
-									"key": "Alt-Svc",
-									"value": "clear"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"access_token\": \"{{accessToken}}\",\n    \"scope\": \"openid\",\n    \"id_token\": \"{{idToken}}\",\n    \"token_type\": \"Bearer\",\n    \"expires_in\": 3599\n}"
-						}
-					]
-				},
-				{
-					"name": "Get M2M (Service) token - Client Credentials Grant",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "ac7f9a4c-3d98-4004-a573-ff5ae1f2eeb1",
-								"exec": [
-									"var jsonData = JSON.parse(responseBody);",
-									"postman.setEnvironmentVariable(\"appAccessToken\", jsonData.access_token);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "password",
-									"value": "{{serviceClientSecret}}",
-									"type": "string"
-								},
-								{
-									"key": "username",
-									"value": "{{serviceClientId}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded"
-							}
-						],
-						"body": {
-							"mode": "urlencoded",
-							"urlencoded": [
-								{
-									"key": "scope",
-									"value": "app.read email-template.read password-policy.read",
-									"type": "text"
-								},
-								{
-									"key": "grant_type",
-									"value": "client_credentials",
-									"type": "text"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{oauth2Url}}/access_token",
-							"host": [
-								"{{oauth2Url}}"
-							],
-							"path": [
-								"access_token"
-							]
-						},
-						"description": "Requires a Client ID and Client Secret for the service app. This call sets up a base64-encoded value for the service app via `Basic Auth` under authentication, using these values.\n\nReturns the following tokens specific to the service app:\n* access_token\n\nYou'll need this token for other REST calls for the service app."
-					},
-					"response": [
-						{
-							"name": "Get M2M (Service) token - Client Credentials Grant",
-							"originalRequest": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/x-www-form-urlencoded"
-									}
-								],
-								"body": {
-									"mode": "urlencoded",
-									"urlencoded": [
-										{
-											"key": "scope",
-											"value": "app.read email-template.read password-policy.read user.reset-password user.recover-username user.create user.read user.update",
-											"type": "text"
-										},
-										{
-											"key": "grant_type",
-											"value": "client_credentials",
-											"type": "text"
-										}
-									]
-								},
-								"url": {
-									"raw": "{{oauth2Url}}/access_token",
-									"host": [
-										"{{oauth2Url}}"
-									],
-									"path": [
-										"access_token"
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "X-Frame-Options",
-									"value": "SAMEORIGIN"
-								},
-								{
-									"key": "Pragma",
-									"value": "no-cache"
-								},
-								{
-									"key": "Cache-Control",
-									"value": "no-store"
-								},
-								{
-									"key": "Date",
-									"value": "Thu, 07 Mar 2019 15:14:55 GMT"
-								},
-								{
-									"key": "Accept-Ranges",
-									"value": "bytes"
-								},
-								{
-									"key": "Vary",
-									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
-								},
-								{
-									"key": "Content-Type",
-									"value": "application/json"
-								},
-								{
-									"key": "Transfer-Encoding",
-									"value": "chunked"
-								},
-								{
-									"key": "Via",
-									"value": "1.1 google"
-								},
-								{
-									"key": "Alt-Svc",
-									"value": "clear"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"access_token\": \"{{serviceAccessToken}}\",\n    \"scope\": \"user.update app.read user.recover-username user.read user.create password-policy.read email-template.read user.reset-password\",\n    \"token_type\": \"Bearer\",\n    \"expires_in\": 3599\n}"
-						}
-					]
-				},
-				{
-					"name": "Discover",
-					"request": {
-						"auth": {
-							"type": "noauth"
-						},
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{oauth2Url}}/.well-known/openid-configuration",
-							"host": [
-								"{{oauth2Url}}"
-							],
-							"path": [
-								".well-known",
-								"openid-configuration"
-							]
-						},
-						"description": "Retrieves configuration data, including:\n\n* Endpoints.\n* Default scopes. For a full list, see our documentation on <a href=\"https://developer-cloud.forgerock.com/reference/scopes/\" target=\"_blank\">Scopes</a>.\n* Encryption and digital signature algorithms. \n* Supported claims, such as `address` and `phone_number`."
-					},
-					"response": [
-						{
-							"name": "Discover",
-							"originalRequest": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{oauth2Url}}/.well-known/openid-configuration",
-									"host": [
-										"{{oauth2Url}}"
-									],
-									"path": [
-										".well-known",
-										"openid-configuration"
-									]
-								}
-							},
-							"status": "OK",
-							"code": 200,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "X-Frame-Options",
-									"value": "SAMEORIGIN"
-								},
-								{
-									"key": "Date",
-									"value": "Thu, 07 Mar 2019 18:47:26 GMT"
-								},
-								{
-									"key": "Accept-Ranges",
-									"value": "bytes"
-								},
-								{
-									"key": "Vary",
-									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
-								},
-								{
-									"key": "Content-Type",
-									"value": "application/json;charset=UTF-8"
-								},
-								{
-									"key": "Transfer-Encoding",
-									"value": "chunked"
-								},
-								{
-									"key": "Via",
-									"value": "1.1 google"
-								},
-								{
-									"key": "Alt-Svc",
-									"value": "clear"
-								}
-							],
-							"cookie": [],
-							"body": "{\n    \"request_parameter_supported\": true,\n    \"claims_parameter_supported\": false,\n    \"introspection_endpoint\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/introspect\",\n    \"check_session_iframe\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/connect/checkSession\",\n    \"scopes_supported\": [\n        \"address\",\n        \"phone\",\n        \"openid\",\n        \"profile\",\n        \"email\"\n    ],\n    \"issuer\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2\",\n    \"id_token_encryption_enc_values_supported\": [\n        \"A256GCM\",\n        \"A192GCM\",\n        \"A128GCM\",\n        \"A128CBC-HS256\",\n        \"A192CBC-HS384\",\n        \"A256CBC-HS512\"\n    ],\n    \"acr_values_supported\": [],\n    \"userinfo_encryption_enc_values_supported\": [\n        \"A256GCM\",\n        \"A192GCM\",\n        \"A128GCM\",\n        \"A128CBC-HS256\",\n        \"A192CBC-HS384\",\n        \"A256CBC-HS512\"\n    ],\n    \"authorization_endpoint\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/authorize\",\n    \"request_object_encryption_enc_values_supported\": [\n        \"A256GCM\",\n        \"A192GCM\",\n        \"A128GCM\",\n        \"A128CBC-HS256\",\n        \"A192CBC-HS384\",\n        \"A256CBC-HS512\"\n    ],\n    \"rcs_request_encryption_alg_values_supported\": [\n        \"RSA-OAEP\",\n        \"RSA-OAEP-256\",\n        \"A128KW\",\n        \"RSA1_5\",\n        \"A256KW\",\n        \"dir\",\n        \"A192KW\"\n    ],\n    \"claims_supported\": [\n        \"zoneinfo\",\n        \"address\",\n        \"profile\",\n        \"name\",\n        \"phone_number\",\n        \"given_name\",\n        \"locale\",\n        \"family_name\",\n        \"email\"\n    ],\n    \"userinfo_signing_alg_values_supported\": [\n        \"ES384\",\n        \"HS256\",\n        \"HS512\",\n        \"ES256\",\n        \"RS256\",\n        \"HS384\",\n        \"ES512\"\n    ],\n    \"rcs_request_signing_alg_values_supported\": [\n        \"PS384\",\n        \"ES384\",\n        \"RS384\",\n        \"HS256\",\n        \"HS512\",\n        \"ES256\",\n        \"RS256\",\n        \"HS384\",\n        \"ES512\",\n        \"PS256\",\n        \"PS512\",\n        \"RS512\"\n    ],\n    \"token_endpoint_auth_methods_supported\": [\n        \"client_secret_post\",\n        \"private_key_jwt\",\n        \"client_secret_basic\"\n    ],\n    \"token_endpoint\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/access_token\",\n    \"response_types_supported\": [\n        \"code token id_token\",\n        \"code\",\n        \"code id_token\",\n        \"device_code\",\n        \"id_token\",\n        \"code token\",\n        \"token\",\n        \"token id_token\"\n    ],\n    \"request_uri_parameter_supported\": true,\n    \"rcs_response_encryption_enc_values_supported\": [\n        \"A256GCM\",\n        \"A192GCM\",\n        \"A128GCM\",\n        \"A128CBC-HS256\",\n        \"A192CBC-HS384\",\n        \"A256CBC-HS512\"\n    ],\n    \"userinfo_encryption_alg_values_supported\": [\n        \"RSA-OAEP\",\n        \"RSA-OAEP-256\",\n        \"A128KW\",\n        \"A256KW\",\n        \"RSA1_5\",\n        \"dir\",\n        \"A192KW\"\n    ],\n    \"grant_types_supported\": [\n        \"implicit\",\n        \"refresh_token\",\n        \"urn:ietf:params:oauth:grant-type:saml2-bearer\",\n        \"password\",\n        \"client_credentials\",\n        \"urn:ietf:params:oauth:grant-type:device_code\",\n        \"authorization_code\",\n        \"urn:ietf:params:oauth:grant-type:uma-ticket\"\n    ],\n    \"end_session_endpoint\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/connect/endSession\",\n    \"rcs_request_encryption_enc_values_supported\": [\n        \"A256GCM\",\n        \"A192GCM\",\n        \"A128GCM\",\n        \"A128CBC-HS256\",\n        \"A192CBC-HS384\",\n        \"A256CBC-HS512\"\n    ],\n    \"version\": \"3.0\",\n    \"rcs_response_encryption_alg_values_supported\": [\n        \"RSA-OAEP\",\n        \"RSA-OAEP-256\",\n        \"A128KW\",\n        \"A256KW\",\n        \"RSA1_5\",\n        \"dir\",\n        \"A192KW\"\n    ],\n    \"userinfo_endpoint\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/userinfo\",\n    \"token_endpoint_auth_signing_alg_values_supported\": [\n        \"PS384\",\n        \"RS384\",\n        \"ES384\",\n        \"HS256\",\n        \"HS512\",\n        \"ES256\",\n        \"RS256\",\n        \"HS384\",\n        \"ES512\",\n        \"PS256\",\n        \"PS512\",\n        \"RS512\"\n    ],\n    \"id_token_encryption_alg_values_supported\": [\n        \"RSA-OAEP\",\n        \"RSA-OAEP-256\",\n        \"A128KW\",\n        \"A256KW\",\n        \"RSA1_5\",\n        \"dir\",\n        \"A192KW\"\n    ],\n    \"jwks_uri\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/connect/jwk_uri\",\n    \"subject_types_supported\": [\n        \"public\"\n    ],\n    \"id_token_signing_alg_values_supported\": [\n        \"PS384\",\n        \"ES384\",\n        \"RS384\",\n        \"HS256\",\n        \"HS512\",\n        \"ES256\",\n        \"RS256\",\n        \"HS384\",\n        \"ES512\",\n        \"PS256\",\n        \"PS512\",\n        \"RS512\"\n    ],\n    \"registration_endpoint\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/register\",\n    \"request_object_signing_alg_values_supported\": [\n        \"PS384\",\n        \"ES384\",\n        \"RS384\",\n        \"HS256\",\n        \"HS512\",\n        \"ES256\",\n        \"RS256\",\n        \"HS384\",\n        \"ES512\",\n        \"PS256\",\n        \"PS512\",\n        \"RS512\"\n    ],\n    \"request_object_encryption_alg_values_supported\": [\n        \"RSA-OAEP\",\n        \"RSA-OAEP-256\",\n        \"A128KW\",\n        \"RSA1_5\",\n        \"A256KW\",\n        \"dir\",\n        \"A192KW\"\n    ],\n    \"rcs_response_signing_alg_values_supported\": [\n        \"PS384\",\n        \"ES384\",\n        \"RS384\",\n        \"HS256\",\n        \"HS512\",\n        \"ES256\",\n        \"RS256\",\n        \"HS384\",\n        \"ES512\",\n        \"PS256\",\n        \"PS512\",\n        \"RS512\"\n    ]\n}"
-						}
-					]
-				}
-			],
-			"description": "Supports authentication of users to access apps. Some Authentication API endpoints support creation of app and user access tokens. You can then use those access tokens in the Management API.\n\nYou can use these REST calls to build authentication into your apps.\n\nTo take full advantage of the Management API, include appropriate scopes in requests to authorization endpoints. The Authentication API then includes the scope in the output access token. For more information, see our documentation on <a href=\"https://developer-cloud.forgerock.com/reference/scopes/\" target=\"_blank\">scopes</a>.",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"id": "2b0ceab8-13c5-48ca-8092-708651935099",
-						"type": "text/javascript",
-						"exec": [
-							""
-						]
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"id": "d3b829d4-6dbe-44d8-9e63-f3643d0e43a5",
-						"type": "text/javascript",
-						"exec": [
-							""
-						]
-					}
-				}
-			]
-		},
 		{
 			"name": "Management APIs",
 			"item": [
 				{
 					"name": "Apps",
 					"item": [
+						{
+							"name": "Native/Spa Apps",
+							"item": [
+								{
+									"name": "Create a Native/SPA App",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "1fd2a55a-d732-4e0e-ba83-6f594d33b7df",
+												"exec": [
+													"var jsonData = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"spaAppClientId\", jsonData.clientId);",
+													"postman.setEnvironmentVariable(\"spaAppClientSecret\", jsonData.secret)"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{accessToken}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"accessTokenLifetime\": 3600,\n  \"apiScopes\": [\n    \"me.read\",\n    \"me.update\",\n    \"me.update-password\",\n    \"password-policy.read\",\n    \"user.reset-password\",\n    \"user.recover-username\",\n    \"user.create\",\n    \"user.read\",\n    \"openid\",\n    \"profile\",\n    \"email\"\n  ],\n  \"authorizationCodeLifetime\": 120,\n  \"customClaims\": {},\n  \"description\": \"My super awesome app\",\n  \"enabled\": true,\n  \"grantTypes\": {\n    \"authorizationCode\": true,\n    \"refreshToken\": true\n  },\n  \"jwtSigningAlgorithm\": \"RS256\",\n  \"jwtTokenLifetime\": 3600,\n  \"loginRedirectUris\": [\"https://example.com/homeLogin/\"],\n  \"logoutRedirectUris\": [\"https://example.com/homeLogout/\"],\n  \"name\": \"Mock App\",\n  \"refreshTokenLifetime\": 604800,\n  \"type\": \"spa\"\n}\n"
+										},
+										"url": {
+											"raw": "{{tenantApiV1Url}}/apps",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"apps"
+											]
+										},
+										"description": "Creates an OAuth 2.0 Native/SPA app. Returns the app configururation.\n\nUse the access token (Bearer) that you get when logging into ui-{{tenantName}}.forgeblocks.com.\n\nThe call assigns a client ID. As the source for native apps are available to the browser, no client secret is created.\n\nRequirement: include: `\"type\" : \"spa\"` in the --data."
+									},
+									"response": [
+										{
+											"name": "Create a Native/SPA App",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"name": "Content-Type",
+														"type": "text",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"accessTokenLifetime\": 3600,\n  \"apiScopes\": [\n    \"me.read\",\n    \"me.update\",\n    \"me.update-password\",\n    \"password-policy.read\",\n    \"user.reset-password\",\n    \"user.recover-username\",\n    \"user.create\",\n    \"user.read\",\n    \"openid\",\n    \"profile\",\n    \"email\"\n  ],\n  \"authorizationCodeLifetime\": 120,\n  \"customClaims\": {},\n  \"description\": \"My super awesome app\",\n  \"enabled\": true,\n  \"grantTypes\": {\n    \"authorizationCode\": true,\n    \"refreshToken\": true\n  },\n  \"jwtSigningAlgorithm\": \"RS256\",\n  \"jwtTokenLifetime\": 3600,\n  \"loginRedirectUris\": [\"https://example.com/homeLogin/\"],\n  \"logoutRedirectUris\": [\"https://example.com/homeLogout/\"],\n  \"name\": \"Mock App\",\n  \"refreshTokenLifetime\": 604800,\n  \"type\": \"spa\"\n}\n"
+												},
+												"url": {
+													"raw": "{{tenantApiV1Url}}/apps",
+													"host": [
+														"{{tenantApiV1Url}}"
+													],
+													"path": [
+														"apps"
+													]
+												}
+											},
+											"status": "Created",
+											"code": 201,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "X-DNS-Prefetch-Control",
+													"value": "off"
+												},
+												{
+													"key": "X-Frame-Options",
+													"value": "SAMEORIGIN"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=15552000; includeSubDomains"
+												},
+												{
+													"key": "X-Download-Options",
+													"value": "noopen"
+												},
+												{
+													"key": "X-Content-Type-Options",
+													"value": "nosniff"
+												},
+												{
+													"key": "X-XSS-Protection",
+													"value": "1; mode=block"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8"
+												},
+												{
+													"key": "Content-Length",
+													"value": "667"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"29b-2Wa+4QVzqM7gEIwvEp1pCUifjh4\""
+												},
+												{
+													"key": "Date",
+													"value": "Mon, 01 Jul 2019 18:30:07 GMT"
+												},
+												{
+													"key": "Via",
+													"value": "1.1 google"
+												},
+												{
+													"key": "Alt-Svc",
+													"value": "clear"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"me.read\",\n        \"me.update\",\n        \"me.update-password\",\n        \"password-policy.read\",\n        \"user.reset-password\",\n        \"user.recover-username\",\n        \"user.create\",\n        \"user.read\",\n        \"openid\",\n        \"profile\",\n        \"email\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"87dd52fc10ed9be5198071cbddbecea8\",\n    \"customClaims\": {},\n    \"description\": \"My super awesome app\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"authorizationCode\": true,\n        \"refreshToken\": true\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [\n        \"https://example.com/homeLogin/\"\n    ],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [\n        \"https://example.com/homeLogout/\"\n    ],\n    \"name\": \"Mock App\",\n    \"refreshTokenLifetime\": 604800,\n    \"type\": \"spa\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Update Native/SPA App",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "b8055a85-9dc6-4c97-abbb-3a3d7dd2febf",
+												"exec": [
+													"if (200 == responseCode.code) {",
+													"    var jsonData = JSON.parse(responseBody);",
+													"    postman.setEnvironmentVariable(\"clientId\", jsonData.clientId);",
+													"    postman.setEnvironmentVariable(\"clientSecret\", jsonData.secret);",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{accessToken}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n      \"me.read\",\n      \"me.update\",\n      \"me.update-password\",\n      \"password-policy.read\",\n      \"user.reset-password\",\n      \"user.recover-username\",\n      \"user.create\",\n      \"user.read\",\n      \"openid\",\n      \"profile\",\n      \"email\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"{{spaAppClientId}}\",\n    \"customClaims\": {},\n    \"description\": \"My great food app, modified\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"authorizationCode\": true,\n        \"refreshToken\": true\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [\n        \"https://example.com/homeLogin/\"\n    ],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [\n        \"https://example.com/homeLogout/\"\n    ],\n    \"name\": \"Top Foods\",\n    \"refreshTokenLifetime\": 604800,\n    \"type\": \"spa\"\n}"
+										},
+										"url": {
+											"raw": "{{tenantApiV1Url}}/apps/{{spaAppClientId}}",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"apps",
+												"{{spaAppClientId}}"
+											]
+										},
+										"description": "Updates the configuration of an existing Native/SPA application client"
+									},
+									"response": [
+										{
+											"name": "Update Native/Spa App",
+											"originalRequest": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"me.read\",\n        \"me.update\",\n        \"password-policy.read\",\n        \"user.reset-password\",\n        \"user.recover-username\",\n        \"user.create\",\n        \"user.read\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"63f650d1c158e4a2260b0fe793630ec3\",\n    \"customClaims\": {},\n    \"description\": \"My great food app, modified\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"authorizationCode\": true,\n        \"clientCredentials\": true,\n        \"password\": true,\n        \"refreshToken\": true\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [\n        \"http://localhost:9080/callback,http://localhost:9080/callback/non-hosted\"\n    ],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [\n        \"http://localhost:9080/\"\n    ],\n    \"name\": \"Top Foods\",\n    \"refreshTokenLifetime\": 604800,\n    \"type\": \"web\"\n}"
+												},
+												"url": {
+													"raw": "{{tenantApiV1Url}}/apps/{{spaAppClientId}}",
+													"host": [
+														"{{tenantApiV1Url}}"
+													],
+													"path": [
+														"apps",
+														"{{spaAppClientId}}"
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "X-DNS-Prefetch-Control",
+													"value": "off"
+												},
+												{
+													"key": "X-Frame-Options",
+													"value": "SAMEORIGIN"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=15552000; includeSubDomains"
+												},
+												{
+													"key": "X-Download-Options",
+													"value": "noopen"
+												},
+												{
+													"key": "X-Content-Type-Options",
+													"value": "nosniff"
+												},
+												{
+													"key": "X-XSS-Protection",
+													"value": "1; mode=block"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8"
+												},
+												{
+													"key": "Content-Length",
+													"value": "715"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"2cb-XoRWvMEzRbXCHI1s0+dQikbnYxg\""
+												},
+												{
+													"key": "Date",
+													"value": "Tue, 11 Jun 2019 19:46:04 GMT"
+												},
+												{
+													"key": "Via",
+													"value": "1.1 google"
+												},
+												{
+													"key": "Alt-Svc",
+													"value": "clear"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"me.read\",\n        \"me.update\",\n        \"password-policy.read\",\n        \"user.reset-password\",\n        \"user.recover-username\",\n        \"user.create\",\n        \"user.read\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"63f650d1c158e4a2260b0fe793630ec3\",\n    \"customClaims\": {},\n    \"description\": \"My great food app, modified\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"authorizationCode\": true,\n        \"clientCredentials\": true,\n        \"password\": true,\n        \"refreshToken\": true\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [\n        \"http://localhost:9080/callback,http://localhost:9080/callback/non-hosted\"\n    ],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [\n        \"http://localhost:9080/\"\n    ],\n    \"name\": \"Top Foods\",\n    \"refreshTokenLifetime\": 604800,\n    \"secret\": null,\n    \"type\": \"web\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Regenerate Native/SPA App Secret",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "9be8101d-3a2c-4c58-b6cf-610c50ce8ec9",
+												"exec": [
+													"var jsonData = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"spaAppClientId\", jsonData.clientId);",
+													"postman.setEnvironmentVariable(\"spaAppClientSecret\", jsonData.secret);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{accessToken}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{tenantApiV1Url}}/apps/refresh/{{spaAppClientId}}",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"apps",
+												"refresh",
+												"{{spaAppClientId}}"
+											]
+										},
+										"description": "Generates a new client secret for the app."
+									},
+									"response": [
+										{
+											"name": "Regenerate Native/SPA App Secret",
+											"originalRequest": {
+												"method": "POST",
+												"header": [],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{tenantApiV1Url}}/apps/refresh/{{spaAppClientId}}",
+													"host": [
+														"{{tenantApiV1Url}}"
+													],
+													"path": [
+														"apps",
+														"refresh",
+														"{{spaAppClientId}}"
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "X-DNS-Prefetch-Control",
+													"value": "off"
+												},
+												{
+													"key": "X-Frame-Options",
+													"value": "SAMEORIGIN"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=15552000; includeSubDomains"
+												},
+												{
+													"key": "X-Download-Options",
+													"value": "noopen"
+												},
+												{
+													"key": "X-Content-Type-Options",
+													"value": "nosniff"
+												},
+												{
+													"key": "X-XSS-Protection",
+													"value": "1; mode=block"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8"
+												},
+												{
+													"key": "Content-Length",
+													"value": "731"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"2db-uvxFhpm46zj7LhO1ZOOyhf6mtxo\""
+												},
+												{
+													"key": "Date",
+													"value": "Mon, 01 Jul 2019 18:37:28 GMT"
+												},
+												{
+													"key": "Via",
+													"value": "1.1 google"
+												},
+												{
+													"key": "Alt-Svc",
+													"value": "clear"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"me.read\",\n        \"me.update\",\n        \"me.update-password\",\n        \"password-policy.read\",\n        \"user.reset-password\",\n        \"user.recover-username\",\n        \"user.create\",\n        \"user.read\",\n        \"openid\",\n        \"profile\",\n        \"email\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"87dd52fc10ed9be5198071cbddbecea8\",\n    \"customClaims\": {},\n    \"description\": \"My great food app, modified\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"authorizationCode\": true,\n        \"refreshToken\": true\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [\n        \"https://example.com/homeLogin/\"\n    ],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [\n        \"https://example.com/homeLogout/\"\n    ],\n    \"name\": \"Top Foods\",\n    \"refreshTokenLifetime\": 604800,\n    \"secret\": \"n66GmxvksXeFNx4FqMtVv6xaHPQHnCtybxocEReGOkQ=\",\n    \"type\": \"spa\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Delete Native/SPA App",
+									"request": {
+										"auth": {
+											"type": "noauth"
+										},
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{accessToken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{tenantApiV1Url}}/apps/{{spaAppClientId}}",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"apps",
+												"{{spaAppClientId}}"
+											]
+										},
+										"description": "Deletes an app as specified by its Client ID\n"
+									},
+									"response": [
+										{
+											"name": "Delete app",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer {{accessToken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{tenantApiV1Url}}/apps/{{appClientId}}",
+													"host": [
+														"{{tenantApiV1Url}}"
+													],
+													"path": [
+														"apps",
+														"{{appClientId}}"
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "X-Powered-By",
+													"value": "Express"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8"
+												},
+												{
+													"key": "Content-Length",
+													"value": "3388"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"d3c-JL9cbEsCNlLO0aKhhWXavGs0XHo\""
+												},
+												{
+													"key": "Date",
+													"value": "Fri, 01 Mar 2019 19:33:37 GMT"
+												},
+												{
+													"key": "Via",
+													"value": "1.1 google"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"_id\": \"{{appClientId}}\",\n    \"_rev\": \"-626963567\",\n    \"advancedOAuth2ClientConfig\": {\n        \"descriptions\": {\n            \"inherited\": false,\n            \"value\": [\n                \"App Descroption\"\n            ]\n        },\n        \"requestUris\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"logoUri\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"subjectType\": {\n            \"inherited\": false,\n            \"value\": \"Public\"\n        },\n        \"clientUri\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"name\": {\n            \"inherited\": false,\n            \"value\": [\n                \"\"\n            ]\n        },\n        \"contacts\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"responseTypes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"token\"\n            ]\n        },\n        \"updateAccessToken\": {\n            \"inherited\": false\n        },\n        \"mixUpMitigation\": {\n            \"inherited\": false,\n            \"value\": false\n        },\n        \"policyUri\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"sectorIdentifierUri\": {\n            \"inherited\": false\n        },\n        \"tokenEndpointAuthMethod\": {\n            \"inherited\": false,\n            \"value\": \"client_secret_basic\"\n        },\n        \"isConsentImplied\": {\n            \"inherited\": false,\n            \"value\": true\n        },\n        \"grantTypes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"client_credentials\"\n            ]\n        }\n    },\n    \"signEncOAuth2ClientConfig\": {\n        \"tokenEndpointAuthSigningAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"RS256\"\n        },\n        \"idTokenEncryptionEnabled\": {\n            \"inherited\": false,\n            \"value\": false\n        },\n        \"requestParameterSignedAlg\": {\n            \"inherited\": false\n        },\n        \"clientJwtPublicKey\": {\n            \"inherited\": false\n        },\n        \"idTokenPublicEncryptionKey\": {\n            \"inherited\": false\n        },\n        \"userinfoResponseFormat\": {\n            \"inherited\": false,\n            \"value\": \"JSON\"\n        },\n        \"publicKeyLocation\": {\n            \"inherited\": false,\n            \"value\": \"jwks_uri\"\n        },\n        \"jwkStoreCacheMissCacheTime\": {\n            \"inherited\": false,\n            \"value\": 60000\n        },\n        \"requestParameterEncryptedEncryptionAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"A128CBC-HS256\"\n        },\n        \"userinfoSignedResponseAlg\": {\n            \"inherited\": false\n        },\n        \"idTokenEncryptionAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"RSA-OAEP-256\"\n        },\n        \"requestParameterEncryptedAlg\": {\n            \"inherited\": false\n        },\n        \"jwkSet\": {\n            \"inherited\": false\n        },\n        \"idTokenEncryptionMethod\": {\n            \"inherited\": false,\n            \"value\": \"A128CBC-HS256\"\n        },\n        \"jwksCacheTimeout\": {\n            \"inherited\": false,\n            \"value\": 3600000\n        },\n        \"userinfoEncryptedResponseAlg\": {\n            \"inherited\": false\n        },\n        \"idTokenSignedResponseAlg\": {\n            \"inherited\": false,\n            \"value\": \"HS256\"\n        },\n        \"jwksUri\": {\n            \"inherited\": false,\n            \"value\": \"http://openam:80/oauth2/connect/jwk_uri\"\n        },\n        \"userinfoEncryptedResponseEncryptionAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"A128CBC-HS256\"\n        }\n    },\n    \"coreOpenIDClientConfig\": {\n        \"claims\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"clientSessionUri\": {\n            \"inherited\": false\n        },\n        \"defaultAcrValues\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"jwtTokenLifetime\": {\n            \"inherited\": false,\n            \"value\": 3600\n        },\n        \"defaultMaxAgeEnabled\": {\n            \"inherited\": false,\n            \"value\": false\n        },\n        \"defaultMaxAge\": {\n            \"inherited\": false,\n            \"value\": 600\n        },\n        \"postLogoutRedirectUri\": {\n            \"inherited\": false,\n            \"value\": []\n        }\n    },\n    \"coreOAuth2ClientConfig\": {\n        \"userpassword\": null,\n        \"userpassword-encrypted\": \"{{userPasswordEncrypted}}\",\n        \"defaultScopes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"openid\"\n            ]\n        },\n        \"refreshTokenLifetime\": {\n            \"inherited\": false,\n            \"value\": 604800\n        },\n        \"scopes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"address\",\n                \"phone\",\n                \"profile\",\n                \"email\",\n                \"app.read\",\n                \"email-template.read\",\n                \"password-policy.read\",\n                \"user.reset-password\",\n                \"user.recover-username\",\n                \"user.create\",\n                \"user.read\",\n                \"user.update\"\n            ]\n        },\n        \"status\": {\n            \"inherited\": false,\n            \"value\": \"Active\"\n        },\n        \"accessTokenLifetime\": {\n            \"inherited\": false,\n            \"value\": 3600\n        },\n        \"redirectionUris\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"clientName\": {\n            \"inherited\": false,\n            \"value\": [\n                \"App name\"\n            ]\n        },\n        \"clientType\": {\n            \"inherited\": false,\n            \"value\": \"Confidential\"\n        },\n        \"authorizationCodeLifetime\": {\n            \"inherited\": false,\n            \"value\": 120\n        }\n    },\n    \"coreUmaClientConfig\": {\n        \"claimsRedirectionUris\": {\n            \"inherited\": false,\n            \"value\": []\n        }\n    },\n    \"_type\": {\n        \"_id\": \"OAuth2Client\",\n        \"name\": \"OAuth2 Clients\",\n        \"collection\": true\n    }\n}"
+										}
+									]
+								}
+							],
+							"description": "With the REST calls in this section, you can create, update, and delete Native/SPA apps. If desired, you can also regenerate the client secret for a specified app. Each time you create a *new* Native/SPA app, we've configured a script in this collection to copy the client ID and client secret for the app, for use in other REST calls in this collection.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "f3b75fd1-53c8-424b-add6-5113cb800579",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "b767f784-57a8-44ae-8cfc-82da5b054b02",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Web Apps",
+							"item": [
+								{
+									"name": "Create a New Web App",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "1fd2a55a-d732-4e0e-ba83-6f594d33b7df",
+												"exec": [
+													"var jsonData = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"webAppClientId\", jsonData.clientId);",
+													"postman.setEnvironmentVariable(\"clientId\", jsonData.clientId);",
+													"postman.setEnvironmentVariable(\"webAppClientSecret\", jsonData.secret);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{accessToken}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n  \"accessTokenLifetime\": 3600,\n  \"apiScopes\": [\n    \"me.read\",\n    \"me.update\",\n    \"password-policy.read\",\n    \"password-policy.update\",\n    \"user.reset-password\",\n    \"user.recover-username\",\n    \"user.create\",\n    \"user.read\",\n    \"openid\",\n    \"profile\",\n    \"email\",\n    \"address\",\n    \"phone\"\n  ],\n  \"authorizationCodeLifetime\": 120,\n  \"customClaims\": {},\n  \"description\": \"My great food app\",\n  \"enabled\": true,\n  \"grantTypes\": {\n    \"authorizationCode\": true,\n    \"refreshToken\": true,\n    \"clientCredentials\": true,\n    \"password\": true\n  },\n  \"jwtSigningAlgorithm\": \"RS256\",\n  \"jwtTokenLifetime\": 3600,\n  \"loginRedirectUris\": [\"https://example.com/homeLogin/\"],\n  \"logoutRedirectUris\": [\"https://example.com/homeLogout/\"],\n  \"name\": \"Top Foods\",\n  \"refreshTokenLifetime\": 604800,\n  \"type\": \"web\"\n}"
+										},
+										"url": {
+											"raw": "{{tenantApiV1Url}}/apps",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"apps"
+											]
+										},
+										"description": "Creates an OAuth 2.0 client web app. Returns the web app configururation.\n\nUse the access token (Bearer) that you get when logging into ui-{{tenantName}}.forgeblocks.com.\n\nRequirement: include: `\"type\" : \"web\"` in the --data.\n\n*Note*: To help illustrate later REST calls, this call sets the `password` client grant type to true. This is *not* recommended in production."
+									},
+									"response": [
+										{
+											"name": "Create a New Web App",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"name": "Content-Type",
+														"value": "application/json",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"accessTokenLifetime\": 3600,\n  \"apiScopes\": [\n    \"me.read\",\n    \"me.update\",\n    \"password-policy.read\",\n    \"user.reset-password\",\n    \"user.recover-username\",\n    \"user.create\",\n    \"user.read\"\n  ],\n  \"authorizationCodeLifetime\": 120,\n  \"customClaims\": {},\n  \"description\": \"My great food app\",\n  \"enabled\": true,\n  \"grantTypes\": {\n    \"authorizationCode\": true,\n    \"refreshToken\": true,\n    \"clientCredentials\": true,\n    \"password\": true\n  },\n  \"jwtSigningAlgorithm\": \"RS256\",\n  \"jwtTokenLifetime\": 3600,\n  \"loginRedirectUris\": [\"http://localhost:9080/callback,http://localhost:9080/callback/non-hosted\"],\n  \"logoutRedirectUris\": [\"http://localhost:9080/\"],\n  \"name\": \"Top Foods\",\n  \"refreshTokenLifetime\": 604800,\n  \"type\": \"web\"\n}"
+												},
+												"url": {
+													"raw": "{{tenantApiV1Url}}/apps",
+													"host": [
+														"{{tenantApiV1Url}}"
+													],
+													"path": [
+														"apps"
+													]
+												}
+											},
+											"status": "Created",
+											"code": 201,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "X-DNS-Prefetch-Control",
+													"value": "off"
+												},
+												{
+													"key": "X-Frame-Options",
+													"value": "SAMEORIGIN"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=15552000; includeSubDomains"
+												},
+												{
+													"key": "X-Download-Options",
+													"value": "noopen"
+												},
+												{
+													"key": "X-Content-Type-Options",
+													"value": "nosniff"
+												},
+												{
+													"key": "X-XSS-Protection",
+													"value": "1; mode=block"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8"
+												},
+												{
+													"key": "Content-Length",
+													"value": "747"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"2eb-csivJzynu6I9Faq53bwf7Jf6QnM\""
+												},
+												{
+													"key": "Date",
+													"value": "Tue, 11 Jun 2019 18:57:00 GMT"
+												},
+												{
+													"key": "Via",
+													"value": "1.1 google"
+												},
+												{
+													"key": "Alt-Svc",
+													"value": "clear"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"me.read\",\n        \"me.update\",\n        \"password-policy.read\",\n        \"user.reset-password\",\n        \"user.recover-username\",\n        \"user.create\",\n        \"user.read\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"{{clientId}}\",\n    \"customClaims\": {},\n    \"description\": \"My great food app\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"authorizationCode\": true,\n        \"clientCredentials\": true,\n        \"password\": true,\n        \"refreshToken\": true\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [\n        \"http://localhost:9080/callback,http://localhost:9080/callback/non-hosted\"\n    ],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [\n        \"http://localhost:9080/\"\n    ],\n    \"name\": \"Top Foods\",\n    \"refreshTokenLifetime\": 604800,\n    \"secret\": \"{{clientSecret}}\",\n    \"type\": \"web\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Update Web App.",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "b8055a85-9dc6-4c97-abbb-3a3d7dd2febf",
+												"exec": [
+													"if (200 == responseCode.code) {",
+													"    var jsonData = JSON.parse(responseBody);",
+													"    postman.setEnvironmentVariable(\"clientId\", jsonData.clientId);",
+													"    postman.setEnvironmentVariable(\"clientSecret\", jsonData.secret);",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{accessToken}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n      \"me.read\",\n      \"me.update\",\n      \"password-policy.read\",\n      \"password-policy.update\",\n      \"user.reset-password\",\n      \"user.recover-username\",\n      \"user.create\",\n      \"user.read\",\n      \"openid\",\n      \"profile\",\n      \"email\",\n      \"address\",\n      \"phone\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"{{webAppClientId}}\",\n    \"customClaims\": {},\n    \"description\": \"My great food app, updated\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"authorizationCode\": true,\n        \"clientCredentials\": true,\n        \"password\": true,\n        \"refreshToken\": true\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [\n        \"https://example.com/homeLogin/\"\n    ],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [\n        \"https://exmaple.com/homeLogout/\"\n    ],\n    \"name\": \"Top Foods\",\n    \"refreshTokenLifetime\": 604800,\n    \"type\": \"web\"\n}"
+										},
+										"url": {
+											"raw": "{{tenantApiV1Url}}/apps/{{webAppClientId}}",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"apps",
+												"{{webAppClientId}}"
+											]
+										},
+										"description": "Updates the configuration of an existing web application client."
+									},
+									"response": [
+										{
+											"name": "Update Application Client - Web",
+											"originalRequest": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer {{access_token}}",
+														"disabled": true
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/json",
+														"warning": ""
+													},
+													{
+														"key": "Authorization",
+														"value": "Bearer {{accessToken}}",
+														"warning": "This is a duplicate header and will be overridden by the Authorization header generated by Postman."
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "    {\n    \t\"authorizationCodeLifetime\": 120,\n        \"accessTokenLifetime\": 3600,\n        \"apiScopes\": [\n            \"app.read\",\n            \"app.write\",\n            \"hosted-page-config.read\",\n            \"hosted-page-config.write\",\n            \"password-policy.read\",\n            \"password-policy.write\",\n            \"team-member.read\",\n            \"team-member.write\",\n            \"user.read\",\n            \"user.write\"\n        ],\n\n        \"customClaims\": {},\n        \"description\": \"My great food app\",\n        \"domain\": \"\",\n        \"enabled\": true,\n        \"grantTypes\": {\n            \"authorizationCode\": true,\n            \"refreshToken\": true\n        },\n        \"jwtSigningAlgorithm\": \"HS256\",\n        \"jwtTokenLifetime\": 3600,\n        \"loginRedirectUris\": [\n            \"http://localhost:9080/callback\"\n        ],\n        \"logoUrl\": \"\",\n        \"logoutRedirectUris\": [\n            \"http://localhost:9080/\"\n        ],\n        \"name\": \"New Top Foods\",\n        \"clientId\": \"070462ae12ec98a1e05e65e8c2148802\",\n        \"refreshTokenLifetime\": 604800,\n        \"type\": \"web\"\n        \n    }"
+												},
+												"url": {
+													"raw": "{{tenantApiV1Url}}/apps/55c52e21-f720-4c4c-9cd3-13682900a10a",
+													"host": [
+														"{{tenantApiV1Url}}"
+													],
+													"path": [
+														"apps",
+														"55c52e21-f720-4c4c-9cd3-13682900a10a"
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*",
+													"name": "Access-Control-Allow-Origin",
+													"description": "Specifies a URI that may access the resource. For requests without credentials, the server may specify '*' as a wildcard, thereby allowing any origin to access the resource."
+												},
+												{
+													"key": "Content-Length",
+													"value": "1288",
+													"name": "Content-Length",
+													"description": "The length of the response body in octets (8-bit bytes)"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8",
+													"name": "Content-Type",
+													"description": "The mime type of this content"
+												},
+												{
+													"key": "Date",
+													"value": "Fri, 05 Oct 2018 22:05:57 GMT",
+													"name": "Date",
+													"description": "The date and time that the message was sent"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"508-BaqQQ3d8qtxW9+837nCJwLGhcv0\"",
+													"name": "ETag",
+													"description": "An identifier for a specific version of a resource, often a message digest"
+												},
+												{
+													"key": "Via",
+													"value": "1.1 google",
+													"name": "Via",
+													"description": "Informs the client of proxies through which the response was sent."
+												},
+												{
+													"key": "X-Powered-By",
+													"value": "Express",
+													"name": "X-Powered-By",
+													"description": "Specifies the technology (ASP.NET, PHP, JBoss, e.g.) supporting the web application (version details are often in X-Runtime, X-Version, or X-AspNet-Version)"
+												}
+											],
+											"cookie": [
+												{
+													"expires": "Invalid Date",
+													"httpOnly": false,
+													"domain": "forgeblocks.com",
+													"path": "/",
+													"secure": false,
+													"value": "lqun1BrLOjUDf9nTxZKQM3gTt1Q.*AAJTSQACMDIAAlNLABxNRHArUGZ4TXB2MzJGMUU2dnlaczY2Y3ZVM3c9AAR0eXBlAANDVFMAAlMxAAIwMQ..*",
+													"key": "iPlanetDirectoryPro"
+												}
+											],
+											"body": "{\n  \"accessTokenLifetime\": 3600,\n  \"apiScopes\": [\n    \"app.read\",\n    \"app.update\",\n    \"hosted-page-config.read\",\n    \"hosted-page-config.update\",\n    \"password-policy.read\",\n    \"password-policy.update\",\n    \"user.read\",\n    \"user.update\"\n  ],\n  \"authorizationCodeLifetime\": 120,\n  \"clientId\": \"{{appClientId}}\",\n  \"customClaims\": {},\n  \"description\": \"My great food app\",\n  \"domain\": \"\",\n  \"enabled\": true,\n  \"grantTypes\": {\n    \"authorizationCode\": true,\n    \"clientCredentials\": true,\n    \"refreshToken\": true\n  },\n  \"jwtSigningAlgorithm\": \"HS256\",\n  \"jwtTokenLifetime\": 3600,\n  \"loginRedirectUris\": [\n    \"http://localhost:9080/callback\"\n  ],\n  \"logoUrl\": \"\",\n  \"logoutRedirectUris\": [\n    \"http://localhost:9080/\"\n  ],\n  \"name\": \"New Top Foods\",\n  \"refreshTokenLifetime\": 604800,\n  \"secret\": null,\n  \"type\": \"web\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Regenerate Web App Secret",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "0fe62f1e-348b-4353-bcb1-efa0a1cdce26",
+												"exec": [
+													"var jsonData = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"webAppClientSecret\", jsonData.secret);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{accessToken}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{tenantApiV1Url}}/apps/refresh/{{webAppClientId}}",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"apps",
+												"refresh",
+												"{{webAppClientId}}"
+											]
+										},
+										"description": "Generates a new client secret for the app."
+									},
+									"response": [
+										{
+											"name": "Regenerate Web App Secret",
+											"originalRequest": {
+												"method": "POST",
+												"header": [],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{tenantApiV1Url}}/apps/refresh/{{webAppClientId}}",
+													"host": [
+														"{{tenantApiV1Url}}"
+													],
+													"path": [
+														"apps",
+														"refresh",
+														"{{webAppClientId}}"
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "X-DNS-Prefetch-Control",
+													"value": "off"
+												},
+												{
+													"key": "X-Frame-Options",
+													"value": "SAMEORIGIN"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=15552000; includeSubDomains"
+												},
+												{
+													"key": "X-Download-Options",
+													"value": "noopen"
+												},
+												{
+													"key": "X-Content-Type-Options",
+													"value": "nosniff"
+												},
+												{
+													"key": "X-XSS-Protection",
+													"value": "1; mode=block"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8"
+												},
+												{
+													"key": "Content-Length",
+													"value": "756"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"2f4-D91srXJ6vB8A4FXWFc6Uhn/N4Uw\""
+												},
+												{
+													"key": "Date",
+													"value": "Fri, 14 Jun 2019 00:43:15 GMT"
+												},
+												{
+													"key": "Via",
+													"value": "1.1 google"
+												},
+												{
+													"key": "Alt-Svc",
+													"value": "clear"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"me.read\",\n        \"me.update\",\n        \"password-policy.read\",\n        \"user.reset-password\",\n        \"user.recover-username\",\n        \"user.create\",\n        \"user.read\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"3b22ed3c0a876cfc605d1ee1c767dea2\",\n    \"customClaims\": {},\n    \"description\": \"My great food app, updated\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"authorizationCode\": true,\n        \"clientCredentials\": true,\n        \"password\": true,\n        \"refreshToken\": true\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [\n        \"http://localhost:9080/callback,http://localhost:9080/callback/non-hosted\"\n    ],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [\n        \"http://localhost:9080/\"\n    ],\n    \"name\": \"Top Foods\",\n    \"refreshTokenLifetime\": 604800,\n    \"secret\": \"u3TsumZM9/JoqCCB44PqRnWiDO5qjKo1YoSe8exVaMw=\",\n    \"type\": \"web\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Delete Web App",
+									"request": {
+										"auth": {
+											"type": "noauth"
+										},
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{accessToken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{tenantApiV1Url}}/apps/{{webAppClientId}}",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"apps",
+												"{{webAppClientId}}"
+											]
+										},
+										"description": "Deletes an app as specified by its client ID.\n"
+									},
+									"response": [
+										{
+											"name": "Delete app",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer {{accessToken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{tenantApiV1Url}}/apps/{{appClientId}}",
+													"host": [
+														"{{tenantApiV1Url}}"
+													],
+													"path": [
+														"apps",
+														"{{appClientId}}"
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "X-Powered-By",
+													"value": "Express"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8"
+												},
+												{
+													"key": "Content-Length",
+													"value": "3388"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"d3c-JL9cbEsCNlLO0aKhhWXavGs0XHo\""
+												},
+												{
+													"key": "Date",
+													"value": "Fri, 01 Mar 2019 19:33:37 GMT"
+												},
+												{
+													"key": "Via",
+													"value": "1.1 google"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"_id\": \"{{appClientId}}\",\n    \"_rev\": \"-626963567\",\n    \"advancedOAuth2ClientConfig\": {\n        \"descriptions\": {\n            \"inherited\": false,\n            \"value\": [\n                \"App Descroption\"\n            ]\n        },\n        \"requestUris\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"logoUri\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"subjectType\": {\n            \"inherited\": false,\n            \"value\": \"Public\"\n        },\n        \"clientUri\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"name\": {\n            \"inherited\": false,\n            \"value\": [\n                \"\"\n            ]\n        },\n        \"contacts\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"responseTypes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"token\"\n            ]\n        },\n        \"updateAccessToken\": {\n            \"inherited\": false\n        },\n        \"mixUpMitigation\": {\n            \"inherited\": false,\n            \"value\": false\n        },\n        \"policyUri\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"sectorIdentifierUri\": {\n            \"inherited\": false\n        },\n        \"tokenEndpointAuthMethod\": {\n            \"inherited\": false,\n            \"value\": \"client_secret_basic\"\n        },\n        \"isConsentImplied\": {\n            \"inherited\": false,\n            \"value\": true\n        },\n        \"grantTypes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"client_credentials\"\n            ]\n        }\n    },\n    \"signEncOAuth2ClientConfig\": {\n        \"tokenEndpointAuthSigningAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"RS256\"\n        },\n        \"idTokenEncryptionEnabled\": {\n            \"inherited\": false,\n            \"value\": false\n        },\n        \"requestParameterSignedAlg\": {\n            \"inherited\": false\n        },\n        \"clientJwtPublicKey\": {\n            \"inherited\": false\n        },\n        \"idTokenPublicEncryptionKey\": {\n            \"inherited\": false\n        },\n        \"userinfoResponseFormat\": {\n            \"inherited\": false,\n            \"value\": \"JSON\"\n        },\n        \"publicKeyLocation\": {\n            \"inherited\": false,\n            \"value\": \"jwks_uri\"\n        },\n        \"jwkStoreCacheMissCacheTime\": {\n            \"inherited\": false,\n            \"value\": 60000\n        },\n        \"requestParameterEncryptedEncryptionAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"A128CBC-HS256\"\n        },\n        \"userinfoSignedResponseAlg\": {\n            \"inherited\": false\n        },\n        \"idTokenEncryptionAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"RSA-OAEP-256\"\n        },\n        \"requestParameterEncryptedAlg\": {\n            \"inherited\": false\n        },\n        \"jwkSet\": {\n            \"inherited\": false\n        },\n        \"idTokenEncryptionMethod\": {\n            \"inherited\": false,\n            \"value\": \"A128CBC-HS256\"\n        },\n        \"jwksCacheTimeout\": {\n            \"inherited\": false,\n            \"value\": 3600000\n        },\n        \"userinfoEncryptedResponseAlg\": {\n            \"inherited\": false\n        },\n        \"idTokenSignedResponseAlg\": {\n            \"inherited\": false,\n            \"value\": \"HS256\"\n        },\n        \"jwksUri\": {\n            \"inherited\": false,\n            \"value\": \"http://openam:80/oauth2/connect/jwk_uri\"\n        },\n        \"userinfoEncryptedResponseEncryptionAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"A128CBC-HS256\"\n        }\n    },\n    \"coreOpenIDClientConfig\": {\n        \"claims\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"clientSessionUri\": {\n            \"inherited\": false\n        },\n        \"defaultAcrValues\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"jwtTokenLifetime\": {\n            \"inherited\": false,\n            \"value\": 3600\n        },\n        \"defaultMaxAgeEnabled\": {\n            \"inherited\": false,\n            \"value\": false\n        },\n        \"defaultMaxAge\": {\n            \"inherited\": false,\n            \"value\": 600\n        },\n        \"postLogoutRedirectUri\": {\n            \"inherited\": false,\n            \"value\": []\n        }\n    },\n    \"coreOAuth2ClientConfig\": {\n        \"userpassword\": null,\n        \"userpassword-encrypted\": \"{{userPasswordEncrypted}}\",\n        \"defaultScopes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"openid\"\n            ]\n        },\n        \"refreshTokenLifetime\": {\n            \"inherited\": false,\n            \"value\": 604800\n        },\n        \"scopes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"address\",\n                \"phone\",\n                \"profile\",\n                \"email\",\n                \"app.read\",\n                \"email-template.read\",\n                \"password-policy.read\",\n                \"user.reset-password\",\n                \"user.recover-username\",\n                \"user.create\",\n                \"user.read\",\n                \"user.update\"\n            ]\n        },\n        \"status\": {\n            \"inherited\": false,\n            \"value\": \"Active\"\n        },\n        \"accessTokenLifetime\": {\n            \"inherited\": false,\n            \"value\": 3600\n        },\n        \"redirectionUris\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"clientName\": {\n            \"inherited\": false,\n            \"value\": [\n                \"App name\"\n            ]\n        },\n        \"clientType\": {\n            \"inherited\": false,\n            \"value\": \"Confidential\"\n        },\n        \"authorizationCodeLifetime\": {\n            \"inherited\": false,\n            \"value\": 120\n        }\n    },\n    \"coreUmaClientConfig\": {\n        \"claimsRedirectionUris\": {\n            \"inherited\": false,\n            \"value\": []\n        }\n    },\n    \"_type\": {\n        \"_id\": \"OAuth2Client\",\n        \"name\": \"OAuth2 Clients\",\n        \"collection\": true\n    }\n}"
+										}
+									]
+								}
+							],
+							"description": "With the REST calls in this section, you can create, update, and delete Web apps. If desired, you can also regenerate the client secret for a specified app. Each time you create a *new* app in this collection, we've configured a script to copy the app's client ID and client secret, for use in other REST calls in this collection.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "dde5d636-2f65-436a-a0f4-a463ba19c747",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "f0ea78d1-7fc8-47de-8529-ff999359c362",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							],
+							"_postman_isSubFolder": true
+						},
+						{
+							"name": "Service (M2M) App",
+							"item": [
+								{
+									"name": "Create a New Service (M2M) App",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "1fd2a55a-d732-4e0e-ba83-6f594d33b7df",
+												"exec": [
+													"var jsonData = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"m2mAppClientId\", jsonData.clientId);",
+													"postman.setEnvironmentVariable(\"m2mAppClientSecret\", jsonData.secret);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{accessToken}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"app.read\",\n        \"app.update\",\n        \"hosted-page-config.read\",\n        \"hosted-page-config.update\",\n        \"password-policy.read\",\n        \"password-policy.update\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"customClaims\": {},\n    \"description\": \"M2Mx\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"clientCredentials\": true\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [],\n    \"name\": \"M2M\",\n    \"refreshTokenLifetime\": 604800,\n    \"type\" : \"m2m\"\n}"
+										},
+										"url": {
+											"raw": "{{tenantApiV1Url}}/apps",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"apps"
+											]
+										},
+										"description": "Creates an OAuth2.0 Service Machine to Machine (M2M) App.. Returns the service app configuration.\n\nUse the access token (Bearer) that you get when logging into ui-{{tenantName}}.forgeblocks.com.\n\nRequirements:\n\n* Include `\"type\" : \"m2m\"`.\n\n* Set the client credential grant type:   \n  \t\"clientCredendials\": true"
+									},
+									"response": [
+										{
+											"name": "Create a New Service (M2M) App",
+											"originalRequest": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"name": "Content-Type",
+														"type": "text",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"app.read\",\n        \"app.update\",\n        \"hosted-page-config.read\",\n        \"hosted-page-config.update\",\n        \"password-policy.read\",\n        \"password-policy.update\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"customClaims\": {},\n    \"description\": \"M2Mx\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"clientCredentials\": true\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [],\n    \"name\": \"M2M\",\n    \"refreshTokenLifetime\": 604800,\n    \"type\" : \"m2m\"\n}"
+												},
+												"url": {
+													"raw": "{{tenantApiV1Url}}/apps",
+													"host": [
+														"{{tenantApiV1Url}}"
+													],
+													"path": [
+														"apps"
+													]
+												}
+											},
+											"status": "Created",
+											"code": 201,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "X-DNS-Prefetch-Control",
+													"value": "off"
+												},
+												{
+													"key": "X-Frame-Options",
+													"value": "SAMEORIGIN"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=15552000; includeSubDomains"
+												},
+												{
+													"key": "X-Download-Options",
+													"value": "noopen"
+												},
+												{
+													"key": "X-Content-Type-Options",
+													"value": "nosniff"
+												},
+												{
+													"key": "X-XSS-Protection",
+													"value": "1; mode=block"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8"
+												},
+												{
+													"key": "Content-Length",
+													"value": "578"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"242-86Rr+oyqfbJ6j7BR/5VrOwkm3GQ\""
+												},
+												{
+													"key": "Date",
+													"value": "Mon, 01 Jul 2019 18:38:22 GMT"
+												},
+												{
+													"key": "Via",
+													"value": "1.1 google"
+												},
+												{
+													"key": "Alt-Svc",
+													"value": "clear"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"app.read\",\n        \"app.update\",\n        \"hosted-page-config.read\",\n        \"hosted-page-config.update\",\n        \"password-policy.read\",\n        \"password-policy.update\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"38cf7854565b6a81f19dd04a6bf3bc6d\",\n    \"customClaims\": {},\n    \"description\": \"M2Mx\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"clientCredentials\": true\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [],\n    \"name\": \"M2M\",\n    \"refreshTokenLifetime\": 604800,\n    \"secret\": \"5kw/xdiwc9oGx9bs0GMHX5V8w9GM5u2qnmzm9kPbVf4=\",\n    \"type\": \"m2m\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Update Service (M2M) App",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "b8055a85-9dc6-4c97-abbb-3a3d7dd2febf",
+												"exec": [
+													"if (200 == responseCode.code) {",
+													"    var jsonData = JSON.parse(responseBody);",
+													"    postman.setEnvironmentVariable(\"clientId\", jsonData.clientId);",
+													"    postman.setEnvironmentVariable(\"clientSecret\", jsonData.secret);",
+													"}"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{accessToken}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"app.read\",\n        \"app.update\",\n        \"hosted-page-config.read\",\n        \"hosted-page-config.update\",\n        \"password-policy.read\",\n        \"password-policy.update\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"{{m2mAppClientId}}\",\n    \"customClaims\": {},\n    \"description\": \"An updated M2M app\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"clientCredentials\": true\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [],\n    \"name\": \"M2M\",\n    \"refreshTokenLifetime\": 604800,\n    \"type\": \"m2m\"\n}"
+										},
+										"url": {
+											"raw": "{{tenantApiV1Url}}/apps/{{m2mAppClientId}}",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"apps",
+												"{{m2mAppClientId}}"
+											]
+										},
+										"description": "Updates the configuration of an existing service (machine-to-machine) app."
+									},
+									"response": [
+										{
+											"name": "Update Service (M2M) App",
+											"originalRequest": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"app.read\",\n        \"app.update\",\n        \"hosted-page-config.read\",\n        \"hosted-page-config.update\",\n        \"password-policy.read\",\n        \"password-policy.update\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"{{client_id}}\",\n    \"customClaims\": {},\n    \"description\": \"An updated M2M app\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"clientCredentials\": true\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [],\n    \"name\": \"M2M\",\n    \"refreshTokenLifetime\": 604800,\n    \"type\": \"m2m\"\n}"
+												},
+												"url": {
+													"raw": "{{tenantApiV1Url}}/apps/{{client_id}}",
+													"host": [
+														"{{tenantApiV1Url}}"
+													],
+													"path": [
+														"apps",
+														"{{client_id}}"
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "X-DNS-Prefetch-Control",
+													"value": "off"
+												},
+												{
+													"key": "X-Frame-Options",
+													"value": "SAMEORIGIN"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=15552000; includeSubDomains"
+												},
+												{
+													"key": "X-Download-Options",
+													"value": "noopen"
+												},
+												{
+													"key": "X-Content-Type-Options",
+													"value": "nosniff"
+												},
+												{
+													"key": "X-XSS-Protection",
+													"value": "1; mode=block"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8"
+												},
+												{
+													"key": "Content-Length",
+													"value": "614"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"266-Q2CSDc0ZnC5OPwEXu+hBSIrqZvw\""
+												},
+												{
+													"key": "Date",
+													"value": "Tue, 11 Jun 2019 21:09:18 GMT"
+												},
+												{
+													"key": "Via",
+													"value": "1.1 google"
+												},
+												{
+													"key": "Alt-Svc",
+													"value": "clear"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"app.read\",\n        \"app.update\",\n        \"hosted-page-config.read\",\n        \"hosted-page-config.update\",\n        \"password-policy.read\",\n        \"password-policy.update\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"{{client_id}}\",\n    \"customClaims\": {},\n    \"description\": \"An updated M2M app\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"authorizationCode\": false,\n        \"clientCredentials\": true,\n        \"password\": false,\n        \"refreshToken\": false\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [],\n    \"name\": \"M2M\",\n    \"refreshTokenLifetime\": 604800,\n    \"secret\": null,\n    \"type\": \"m2m\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Regenerate Service (M2M) App Secret",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "f3d64771-7587-43be-9073-466b775380bc",
+												"exec": [
+													"var jsonData = JSON.parse(responseBody);",
+													"postman.setEnvironmentVariable(\"m2mAppClientId\", jsonData.clientId);",
+													"postman.setEnvironmentVariable(\"m2mAppClientSecret\", jsonData.secret);"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "bearer",
+											"bearer": [
+												{
+													"key": "token",
+													"value": "{{accessToken}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{tenantApiV1Url}}/apps/refresh/{{m2mAppClientId}}",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"apps",
+												"refresh",
+												"{{m2mAppClientId}}"
+											]
+										},
+										"description": "Generates a new client_secret for the app."
+									},
+									"response": [
+										{
+											"name": "Regenerate Web App Secret",
+											"originalRequest": {
+												"method": "POST",
+												"header": [],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{tenantApiV1Url}}/apps/refresh/{{webAppClientId}}",
+													"host": [
+														"{{tenantApiV1Url}}"
+													],
+													"path": [
+														"apps",
+														"refresh",
+														"{{webAppClientId}}"
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "X-DNS-Prefetch-Control",
+													"value": "off"
+												},
+												{
+													"key": "X-Frame-Options",
+													"value": "SAMEORIGIN"
+												},
+												{
+													"key": "Strict-Transport-Security",
+													"value": "max-age=15552000; includeSubDomains"
+												},
+												{
+													"key": "X-Download-Options",
+													"value": "noopen"
+												},
+												{
+													"key": "X-Content-Type-Options",
+													"value": "nosniff"
+												},
+												{
+													"key": "X-XSS-Protection",
+													"value": "1; mode=block"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8"
+												},
+												{
+													"key": "Content-Length",
+													"value": "756"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"2f4-D91srXJ6vB8A4FXWFc6Uhn/N4Uw\""
+												},
+												{
+													"key": "Date",
+													"value": "Fri, 14 Jun 2019 00:43:15 GMT"
+												},
+												{
+													"key": "Via",
+													"value": "1.1 google"
+												},
+												{
+													"key": "Alt-Svc",
+													"value": "clear"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"me.read\",\n        \"me.update\",\n        \"password-policy.read\",\n        \"user.reset-password\",\n        \"user.recover-username\",\n        \"user.create\",\n        \"user.read\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"3b22ed3c0a876cfc605d1ee1c767dea2\",\n    \"customClaims\": {},\n    \"description\": \"My great food app, updated\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"authorizationCode\": true,\n        \"clientCredentials\": true,\n        \"password\": true,\n        \"refreshToken\": true\n    },\n    \"jwtSigningAlgorithm\": \"RS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [\n        \"http://localhost:9080/callback,http://localhost:9080/callback/non-hosted\"\n    ],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [\n        \"http://localhost:9080/\"\n    ],\n    \"name\": \"Top Foods\",\n    \"refreshTokenLifetime\": 604800,\n    \"secret\": \"u3TsumZM9/JoqCCB44PqRnWiDO5qjKo1YoSe8exVaMw=\",\n    \"type\": \"web\"\n}"
+										}
+									]
+								},
+								{
+									"name": "Delete Service App",
+									"request": {
+										"auth": {
+											"type": "noauth"
+										},
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{accessToken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{tenantApiV1Url}}/apps/{{m2mAppClientId}}",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"apps",
+												"{{m2mAppClientId}}"
+											]
+										},
+										"description": "Deletes an app as specified by its Client ID\n"
+									},
+									"response": [
+										{
+											"name": "Delete app",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Authorization",
+														"value": "Bearer {{accessToken}}"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{tenantApiV1Url}}/apps/{{appClientId}}",
+													"host": [
+														"{{tenantApiV1Url}}"
+													],
+													"path": [
+														"apps",
+														"{{appClientId}}"
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "X-Powered-By",
+													"value": "Express"
+												},
+												{
+													"key": "Access-Control-Allow-Origin",
+													"value": "*"
+												},
+												{
+													"key": "Content-Type",
+													"value": "application/json; charset=utf-8"
+												},
+												{
+													"key": "Content-Length",
+													"value": "3388"
+												},
+												{
+													"key": "ETag",
+													"value": "W/\"d3c-JL9cbEsCNlLO0aKhhWXavGs0XHo\""
+												},
+												{
+													"key": "Date",
+													"value": "Fri, 01 Mar 2019 19:33:37 GMT"
+												},
+												{
+													"key": "Via",
+													"value": "1.1 google"
+												}
+											],
+											"cookie": [],
+											"body": "{\n    \"_id\": \"{{appClientId}}\",\n    \"_rev\": \"-626963567\",\n    \"advancedOAuth2ClientConfig\": {\n        \"descriptions\": {\n            \"inherited\": false,\n            \"value\": [\n                \"App Descroption\"\n            ]\n        },\n        \"requestUris\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"logoUri\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"subjectType\": {\n            \"inherited\": false,\n            \"value\": \"Public\"\n        },\n        \"clientUri\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"name\": {\n            \"inherited\": false,\n            \"value\": [\n                \"\"\n            ]\n        },\n        \"contacts\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"responseTypes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"token\"\n            ]\n        },\n        \"updateAccessToken\": {\n            \"inherited\": false\n        },\n        \"mixUpMitigation\": {\n            \"inherited\": false,\n            \"value\": false\n        },\n        \"policyUri\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"sectorIdentifierUri\": {\n            \"inherited\": false\n        },\n        \"tokenEndpointAuthMethod\": {\n            \"inherited\": false,\n            \"value\": \"client_secret_basic\"\n        },\n        \"isConsentImplied\": {\n            \"inherited\": false,\n            \"value\": true\n        },\n        \"grantTypes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"client_credentials\"\n            ]\n        }\n    },\n    \"signEncOAuth2ClientConfig\": {\n        \"tokenEndpointAuthSigningAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"RS256\"\n        },\n        \"idTokenEncryptionEnabled\": {\n            \"inherited\": false,\n            \"value\": false\n        },\n        \"requestParameterSignedAlg\": {\n            \"inherited\": false\n        },\n        \"clientJwtPublicKey\": {\n            \"inherited\": false\n        },\n        \"idTokenPublicEncryptionKey\": {\n            \"inherited\": false\n        },\n        \"userinfoResponseFormat\": {\n            \"inherited\": false,\n            \"value\": \"JSON\"\n        },\n        \"publicKeyLocation\": {\n            \"inherited\": false,\n            \"value\": \"jwks_uri\"\n        },\n        \"jwkStoreCacheMissCacheTime\": {\n            \"inherited\": false,\n            \"value\": 60000\n        },\n        \"requestParameterEncryptedEncryptionAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"A128CBC-HS256\"\n        },\n        \"userinfoSignedResponseAlg\": {\n            \"inherited\": false\n        },\n        \"idTokenEncryptionAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"RSA-OAEP-256\"\n        },\n        \"requestParameterEncryptedAlg\": {\n            \"inherited\": false\n        },\n        \"jwkSet\": {\n            \"inherited\": false\n        },\n        \"idTokenEncryptionMethod\": {\n            \"inherited\": false,\n            \"value\": \"A128CBC-HS256\"\n        },\n        \"jwksCacheTimeout\": {\n            \"inherited\": false,\n            \"value\": 3600000\n        },\n        \"userinfoEncryptedResponseAlg\": {\n            \"inherited\": false\n        },\n        \"idTokenSignedResponseAlg\": {\n            \"inherited\": false,\n            \"value\": \"HS256\"\n        },\n        \"jwksUri\": {\n            \"inherited\": false,\n            \"value\": \"http://openam:80/oauth2/connect/jwk_uri\"\n        },\n        \"userinfoEncryptedResponseEncryptionAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"A128CBC-HS256\"\n        }\n    },\n    \"coreOpenIDClientConfig\": {\n        \"claims\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"clientSessionUri\": {\n            \"inherited\": false\n        },\n        \"defaultAcrValues\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"jwtTokenLifetime\": {\n            \"inherited\": false,\n            \"value\": 3600\n        },\n        \"defaultMaxAgeEnabled\": {\n            \"inherited\": false,\n            \"value\": false\n        },\n        \"defaultMaxAge\": {\n            \"inherited\": false,\n            \"value\": 600\n        },\n        \"postLogoutRedirectUri\": {\n            \"inherited\": false,\n            \"value\": []\n        }\n    },\n    \"coreOAuth2ClientConfig\": {\n        \"userpassword\": null,\n        \"userpassword-encrypted\": \"{{userPasswordEncrypted}}\",\n        \"defaultScopes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"openid\"\n            ]\n        },\n        \"refreshTokenLifetime\": {\n            \"inherited\": false,\n            \"value\": 604800\n        },\n        \"scopes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"address\",\n                \"phone\",\n                \"profile\",\n                \"email\",\n                \"app.read\",\n                \"email-template.read\",\n                \"password-policy.read\",\n                \"user.reset-password\",\n                \"user.recover-username\",\n                \"user.create\",\n                \"user.read\",\n                \"user.update\"\n            ]\n        },\n        \"status\": {\n            \"inherited\": false,\n            \"value\": \"Active\"\n        },\n        \"accessTokenLifetime\": {\n            \"inherited\": false,\n            \"value\": 3600\n        },\n        \"redirectionUris\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"clientName\": {\n            \"inherited\": false,\n            \"value\": [\n                \"App name\"\n            ]\n        },\n        \"clientType\": {\n            \"inherited\": false,\n            \"value\": \"Confidential\"\n        },\n        \"authorizationCodeLifetime\": {\n            \"inherited\": false,\n            \"value\": 120\n        }\n    },\n    \"coreUmaClientConfig\": {\n        \"claimsRedirectionUris\": {\n            \"inherited\": false,\n            \"value\": []\n        }\n    },\n    \"_type\": {\n        \"_id\": \"OAuth2Client\",\n        \"name\": \"OAuth2 Clients\",\n        \"collection\": true\n    }\n}"
+										}
+									]
+								}
+							],
+							"description": "With the REST calls in this section, you can create, update, and delete Service (M2M) apps. (M2M is short for \"machine to machine\".) If desired, you can also regenerate the Client Secret for a specified app. Each time you create a *new* Service (M2M) app, we've configured a script in this collection to copy the Client ID and Client Secret for the app, for use in other REST calls in this collection.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "ca5727af-175e-4b3e-b64d-2cb31c0b404f",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "6ebeccdb-917b-46de-83b9-dd4d7db302c6",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							],
+							"_postman_isSubFolder": true
+						},
 						{
 							"name": "Get Apps",
 							"request": {
@@ -1843,10 +1634,6 @@
 								},
 								"method": "GET",
 								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{tenantApiV1Url}}/apps",
 									"host": [
@@ -1863,17 +1650,7 @@
 									"name": "Get Apps",
 									"originalRequest": {
 										"method": "GET",
-										"header": [
-											{
-												"key": "Authorization",
-												"value": "Bearer {{accessToken}}",
-												"description": "The access_token from a registered client"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
+										"header": [],
 										"url": {
 											"raw": "{{tenantApiV1Url}}/apps",
 											"host": [
@@ -1889,8 +1666,28 @@
 									"_postman_previewlanguage": "json",
 									"header": [
 										{
-											"key": "X-Powered-By",
-											"value": "Express"
+											"key": "X-DNS-Prefetch-Control",
+											"value": "off"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "SAMEORIGIN"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=15552000; includeSubDomains"
+										},
+										{
+											"key": "X-Download-Options",
+											"value": "noopen"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "X-XSS-Protection",
+											"value": "1; mode=block"
 										},
 										{
 											"key": "Access-Control-Allow-Origin",
@@ -1902,23 +1699,27 @@
 										},
 										{
 											"key": "Content-Length",
-											"value": "1367"
+											"value": "2621"
 										},
 										{
 											"key": "ETag",
-											"value": "W/\"557-nrvpVpwRKF6XxqsgbkFgoojtwtI\""
+											"value": "W/\"a3d-wHiE2nGqGsvn+qAnW9/idOmMNuo\""
 										},
 										{
 											"key": "Date",
-											"value": "Thu, 28 Feb 2019 20:27:20 GMT"
+											"value": "Mon, 01 Jul 2019 18:42:13 GMT"
 										},
 										{
 											"key": "Via",
 											"value": "1.1 google"
+										},
+										{
+											"key": "Alt-Svc",
+											"value": "clear"
 										}
 									],
 									"cookie": [],
-									"body": "[\n    {\n        \"accessTokenLifetime\": 3600,\n        \"apiScopes\": [\n            \"app.read\",\n            \"email-template.read\",\n            \"password-policy.read\",\n            \"user.reset-password\",\n            \"user.recover-username\",\n            \"user.create\",\n            \"user.read\",\n            \"user.update\"\n        ],\n        \"authorizationCodeLifetime\": 120,\n        \"clientId\": \"{{appClientId}}\",\n        \"customClaims\": {},\n        \"description\": \"Some App Name\",\n        \"domain\": \"\",\n        \"enabled\": true,\n        \"grantTypes\": {\n            \"authorizationCode\": false,\n            \"clientCredentials\": true,\n            \"password\": false,\n            \"refreshToken\": false\n        },\n        \"jwtSigningAlgorithm\": \"HS256\",\n        \"jwtTokenLifetime\": 3600,\n        \"loginRedirectUris\": [],\n        \"logoUrl\": \"\",\n        \"logoutRedirectUris\": [],\n        \"name\": \"docs36s\",\n        \"refreshTokenLifetime\": 604800,\n        \"secret\": null,\n        \"type\": \"m2m\"\n    },\n    {\n        \"accessTokenLifetime\": 3600,\n        \"apiScopes\": [\n            \"me.read\",\n            \"me.update\",\n            \"me.update-password\",\n            \"password-policy.read\",\n            \"user.reset-password\",\n            \"user.recover-username\",\n            \"user.create\",\n            \"user.read\"\n        ],\n        \"authorizationCodeLifetime\": 120,\n        \"clientId\": \"{{appClientId}}\",\n        \"customClaims\": {},\n        \"description\": \"Docs 36 web app v2\",\n        \"domain\": \"\",\n        \"enabled\": true,\n        \"grantTypes\": {\n            \"authorizationCode\": true,\n            \"clientCredentials\": true,\n            \"password\": true,\n            \"refreshToken\": true\n        },\n        \"jwtSigningAlgorithm\": \"HS256\",\n        \"jwtTokenLifetime\": 3600,\n        \"loginRedirectUris\": [\n            \"http://localhost:9080/callback\",\n            \"http://localhost:9080/callback/non-hosted\"\n        ],\n        \"logoUrl\": \"\",\n        \"logoutRedirectUris\": [\n            \"http://localhost:9080/\"\n        ],\n        \"name\": \"docs36web\",\n        \"refreshTokenLifetime\": 604800,\n        \"secret\": null,\n        \"type\": \"web\"\n    }\n]"
+									"body": "[\n    {\n        \"accessTokenLifetime\": 3600,\n        \"apiScopes\": [\n            \"app.read\",\n            \"app.update\",\n            \"hosted-page-config.read\",\n            \"hosted-page-config.update\",\n            \"password-policy.read\",\n            \"password-policy.update\"\n        ],\n        \"authorizationCodeLifetime\": 120,\n        \"clientId\": \"38cf7854565b6a81f19dd04a6bf3bc6d\",\n        \"customClaims\": {},\n        \"description\": \"M2Mx\",\n        \"domain\": \"\",\n        \"enabled\": true,\n        \"grantTypes\": {\n            \"clientCredentials\": true\n        },\n        \"jwtSigningAlgorithm\": \"RS256\",\n        \"jwtTokenLifetime\": 3600,\n        \"loginRedirectUris\": [],\n        \"logoUrl\": \"\",\n        \"logoutRedirectUris\": [],\n        \"name\": \"M2M\",\n        \"refreshTokenLifetime\": 604800,\n        \"secret\": null,\n        \"type\": \"m2m\"\n    },\n    {\n        \"accessTokenLifetime\": 3600,\n        \"apiScopes\": [\n            \"me.read\",\n            \"me.update\",\n            \"me.update-password\",\n            \"password-policy.read\",\n            \"user.reset-password\",\n            \"user.recover-username\",\n            \"user.create\",\n            \"user.read\",\n            \"openid\",\n            \"profile\",\n            \"email\"\n        ],\n        \"authorizationCodeLifetime\": 120,\n        \"clientId\": \"0e25a24d96ae9ba9112fafe62884107b\",\n        \"customClaims\": {},\n        \"description\": \"My super awesome app\",\n        \"domain\": \"\",\n        \"enabled\": true,\n        \"grantTypes\": {\n            \"authorizationCode\": true,\n            \"refreshToken\": true\n        },\n        \"jwtSigningAlgorithm\": \"RS256\",\n        \"jwtTokenLifetime\": 3600,\n        \"loginRedirectUris\": [\n            \"https://example.com/homeLogin/\"\n        ],\n        \"logoUrl\": \"\",\n        \"logoutRedirectUris\": [\n            \"https://example.com/homeLogout/\"\n        ],\n        \"name\": \"Mock App\",\n        \"refreshTokenLifetime\": 604800,\n        \"type\": \"spa\"\n    },\n    {\n        \"accessTokenLifetime\": 3600,\n        \"apiScopes\": [\n            \"me.read\",\n            \"me.update\",\n            \"password-policy.read\",\n            \"password-policy.update\",\n            \"user.reset-password\",\n            \"user.recover-username\",\n            \"user.create\",\n            \"user.read\",\n            \"openid\",\n            \"profile\",\n            \"email\"\n        ],\n        \"authorizationCodeLifetime\": 120,\n        \"clientId\": \"67412bc46d5005113c25f95641bc40a0\",\n        \"customClaims\": {},\n        \"description\": \"My great food app\",\n        \"domain\": \"\",\n        \"enabled\": true,\n        \"grantTypes\": {\n            \"authorizationCode\": true,\n            \"clientCredentials\": true,\n            \"password\": true,\n            \"refreshToken\": true\n        },\n        \"jwtSigningAlgorithm\": \"RS256\",\n        \"jwtTokenLifetime\": 3600,\n        \"loginRedirectUris\": [\n            \"https://example.com/homeLogin/\"\n        ],\n        \"logoUrl\": \"\",\n        \"logoutRedirectUris\": [\n            \"https://example.com/homeLogout/\"\n        ],\n        \"name\": \"Top Foods\",\n        \"refreshTokenLifetime\": 604800,\n        \"secret\": null,\n        \"type\": \"web\"\n    },\n    {\n        \"accessTokenLifetime\": 3600,\n        \"apiScopes\": [\n            \"me.read\",\n            \"me.update\",\n            \"me.update-password\",\n            \"password-policy.read\",\n            \"user.reset-password\",\n            \"user.recover-username\",\n            \"user.create\",\n            \"user.read\",\n            \"openid\",\n            \"profile\",\n            \"email\"\n        ],\n        \"authorizationCodeLifetime\": 120,\n        \"clientId\": \"87dd52fc10ed9be5198071cbddbecea8\",\n        \"customClaims\": {},\n        \"description\": \"My great food app, modified\",\n        \"domain\": \"\",\n        \"enabled\": true,\n        \"grantTypes\": {\n            \"authorizationCode\": true,\n            \"refreshToken\": true\n        },\n        \"jwtSigningAlgorithm\": \"RS256\",\n        \"jwtTokenLifetime\": 3600,\n        \"loginRedirectUris\": [\n            \"https://example.com/homeLogin/\"\n        ],\n        \"logoUrl\": \"\",\n        \"logoutRedirectUris\": [\n            \"https://example.com/homeLogout/\"\n        ],\n        \"name\": \"Top Foods\",\n        \"refreshTokenLifetime\": 604800,\n        \"secret\": null,\n        \"type\": \"spa\"\n    }\n]"
 								}
 							]
 						},
@@ -1937,18 +1738,14 @@
 								},
 								"method": "GET",
 								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
-									"raw": "{{tenantApiV1Url}}/apps/{{client_id}}",
+									"raw": "{{tenantApiV1Url}}/apps/{{clientId}}",
 									"host": [
 										"{{tenantApiV1Url}}"
 									],
 									"path": [
 										"apps",
-										"{{client_id}}"
+										"{{clientId}}"
 									]
 								},
 								"description": "Retreives configuration details of the specified app. Use the Client ID for the app."
@@ -1965,10 +1762,6 @@
 												"type": "text"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{tenantApiV1Url}}/apps/{{clientId}}",
 											"host": [
@@ -2017,595 +1810,6 @@
 									"body": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"me.read\",\n        \"me.update\",\n        \"me.update-password\",\n        \"password-policy.read\",\n        \"user.reset-password\",\n        \"user.recover-username\",\n        \"user.create\",\n        \"user.read\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"{{clientId}}\",\n    \"customClaims\": {},\n    \"description\": \"App Name\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"authorizationCode\": true,\n        \"clientCredentials\": true,\n        \"password\": true,\n        \"refreshToken\": true\n    },\n    \"jwtSigningAlgorithm\": \"HS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [\n        \"http://localhost:9080/callback\",\n        \"http://localhost:9080/callback/non-hosted\"\n    ],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [\n        \"http://localhost:9080/\"\n    ],\n    \"name\": \"{{appId}}\",\n    \"refreshTokenLifetime\": 604800,\n    \"secret\": null,\n    \"type\": \"web\"\n}"
 								}
 							]
-						},
-						{
-							"name": "Regenerate App Secret",
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{accessToken}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{tenantApiV1Url}}/apps/refresh/{{client_id}}",
-									"host": [
-										"{{tenantApiV1Url}}"
-									],
-									"path": [
-										"apps",
-										"refresh",
-										"{{client_id}}"
-									]
-								},
-								"description": "Generates a new client_secret for the app."
-							},
-							"response": [
-								{
-									"name": "Regenerate App Secret",
-									"originalRequest": {
-										"method": "POST",
-										"header": [],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{tenantApiV1Url}}/apps/refresh/{{clientId}}",
-											"host": [
-												"{{tenantApiV1Url}}"
-											],
-											"path": [
-												"apps",
-												"refresh",
-												"{{clientId}}"
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "X-Powered-By",
-											"value": "Express"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8"
-										},
-										{
-											"key": "Content-Length",
-											"value": "765"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"2fd-LUM8KavRLC9B+ua9NKs2gfADtkg\""
-										},
-										{
-											"key": "Date",
-											"value": "Fri, 01 Mar 2019 19:07:41 GMT"
-										},
-										{
-											"key": "Via",
-											"value": "1.1 google"
-										}
-									],
-									"cookie": [],
-									"body": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"me.read\",\n        \"me.update\",\n        \"me.update-password\",\n        \"password-policy.read\",\n        \"user.reset-password\",\n        \"user.recover-username\",\n        \"user.create\",\n        \"user.read\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"{{appClientId}}\",\n    \"customClaims\": {},\n    \"description\": \"Your Web App\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"authorizationCode\": true,\n        \"clientCredentials\": true,\n        \"password\": true,\n        \"refreshToken\": true\n    },\n    \"jwtSigningAlgorithm\": \"HS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [\n        \"http://localhost:9080/callback\",\n        \"http://localhost:9080/callback/non-hosted\"\n    ],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [\n        \"http://localhost:9080/\"\n    ],\n    \"name\": \"{{tenantName}}\",\n    \"refreshTokenLifetime\": 604800,\n    \"secret\": \"{{appClientSecret}}\",\n    \"type\": \"web\"\n}"
-								}
-							]
-						},
-						{
-							"name": "Create a New Web App",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "1fd2a55a-d732-4e0e-ba83-6f594d33b7df",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{accessToken}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"value": "application/json",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"accessTokenLifetime\": 3600,\n  \"apiScopes\": [\n    \"me.read\",\n    \"me.update\",\n    \"password-policy.read\",\n    \"user.reset-password\",\n    \"user.recover-username\",\n    \"user.create\",\n    \"user.read\"\n  ],\n  \"authorizationCodeLifetime\": 120,\n  \"customClaims\": {},\n  \"description\": \"My great food app\",\n  \"enabled\": true,\n  \"grantTypes\": {\n    \"authorizationCode\": true,\n    \"refreshToken\": true,\n    \"clientCredentials\": true,\n    \"password\": true\n  },\n  \"jwtSigningAlgorithm\": \"HS256\",\n  \"jwtTokenLifetime\": 3600,\n  \"loginRedirectUris\": [\"http://localhost:9080/callback,http://localhost:9080/callback/non-hosted\"],\n  \"logoutRedirectUris\": [\"http://localhost:9080/\"],\n  \"name\": \"Top Foods\",\n  \"refreshTokenLifetime\": 604800,\n  \"type\": \"web\"\n}"
-								},
-								"url": {
-									"raw": "{{tenantApiV1Url}}/apps",
-									"host": [
-										"{{tenantApiV1Url}}"
-									],
-									"path": [
-										"apps"
-									]
-								},
-								"description": "Creates an OAuth 2.0 client web app. Returns the web app configururation.\n\nUse the access token (Bearer) that you get when logging into ui-{{tenantName}}.forgeblocks.com.\n\nRequirement: include: `\"type\" : \"web\"` in the --data."
-							},
-							"response": [
-								{
-									"name": "Create Client Web App",
-									"originalRequest": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "Authorization",
-												"value": "Bearer {{access_token}}",
-												"disabled": true
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "Authorization",
-												"value": "Bearer {{accessToken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"accessTokenLifetime\": 3600,\n  \"authorizationCodeLifetime\": 120,\n  \"customClaims\": {},\n  \"description\": \"My great food app\",\n  \"enabled\": true,\n  \"grantTypes\": {\n    \"authorizationCode\": true,\n    \"refreshToken\": true\n  },\n  \"jwtSigningAlgorithm\": \"HS256\",\n  \"jwtTokenLifetime\": 3600,\n  \"loginRedirectUris\": [\"http://localhost:9080/callback\"],\n  \"logoutRedirectUris\": [\"http://localhost:9080/\"],\n  \"name\": \"Top Foods\",\n  \"refreshTokenLifetime\": 604800,\n  \"type\": \"web\"\n}"
-										},
-										"url": {
-											"raw": "{{tenantApiV1Url}}/apps",
-											"host": [
-												"{{tenantApiV1Url}}"
-											],
-											"path": [
-												"apps"
-											]
-										}
-									},
-									"status": "Created",
-									"code": 201,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*",
-											"name": "Access-Control-Allow-Origin",
-											"description": "Specifies a URI that may access the resource. For requests without credentials, the server may specify '*' as a wildcard, thereby allowing any origin to access the resource."
-										},
-										{
-											"key": "Content-Length",
-											"value": "949",
-											"name": "Content-Length",
-											"description": "The length of the response body in octets (8-bit bytes)"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8",
-											"name": "Content-Type",
-											"description": "The mime type of this content"
-										},
-										{
-											"key": "Date",
-											"value": "Fri, 05 Oct 2018 01:05:59 GMT",
-											"name": "Date",
-											"description": "The date and time that the message was sent"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"3b5-d3ZG9+bKiXg7Cm5k5OTwc5I9lwA\"",
-											"name": "ETag",
-											"description": "An identifier for a specific version of a resource, often a message digest"
-										},
-										{
-											"key": "Via",
-											"value": "1.1 google",
-											"name": "Via",
-											"description": "Informs the client of proxies through which the response was sent."
-										},
-										{
-											"key": "X-Powered-By",
-											"value": "Express",
-											"name": "X-Powered-By",
-											"description": "Specifies the technology (ASP.NET, PHP, JBoss, e.g.) supporting the web application (version details are often in X-Runtime, X-Version, or X-AspNet-Version)"
-										}
-									],
-									"cookie": [],
-									"body": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"app.read\",\n        \"app.write\",\n        \"hosted-page-config.read\",\n        \"hosted-page-config.write\",\n        \"password-policy.read\",\n        \"password-policy.write\",\n        \"team-member.read\",\n        \"team-member.write\",\n        \"user.read\",\n        \"user.write\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"{{appClientId}}\",\n    \"customClaims\": {},\n    \"description\": \"My great food app\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"authorizationCode\": true,\n        \"clientCredentials\": true,\n        \"refreshToken\": true\n    },\n    \"jwtSigningAlgorithm\": \"HS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [\n        \"http://localhost:9080/callback\"\n    ],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [\n        \"http://localhost:9080/\"\n    ],\n    \"name\": \"Top Foods\",\n    \"refreshTokenLifetime\": 604800,\n    \"secret\": \"{{appClientSecret}}\",\n    \"type\": \"web\"\n}"
-								}
-							]
-						},
-						{
-							"name": "Create a New Service (M2M) App",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "1fd2a55a-d732-4e0e-ba83-6f594d33b7df",
-										"exec": [
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{accessToken}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"app.read\",\n        \"app.update\",\n        \"hosted-page-config.read\",\n        \"hosted-page-config.update\",\n        \"password-policy.read\",\n        \"password-policy.update\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"customClaims\": {},\n    \"description\": \"M2Mx\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"clientCredentials\": true\n    },\n    \"jwtSigningAlgorithm\": \"HS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [],\n    \"name\": \"M2M\",\n    \"refreshTokenLifetime\": 604800,\n    \"type\" : \"m2m\"\n}"
-								},
-								"url": {
-									"raw": "{{tenantApiV1Url}}/apps",
-									"host": [
-										"{{tenantApiV1Url}}"
-									],
-									"path": [
-										"apps"
-									]
-								},
-								"description": "Creates an OAuth2.0 Service Machine to Machine (M2M) App.. Returns the service app configuration.\n\nUse the access token (Bearer) that you get when logging into ui-{{tenantName}}.forgeblocks.com.\n\nRequirements:\n\n* Include `\"type\" : \"m2m\"`.\n\n* Set the client credential grant type:   \n  \t\"clientCredendials\": true"
-							},
-							"response": [
-								{
-									"name": "Create a New Service (M2M) App",
-									"originalRequest": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "Content-Type",
-												"name": "Content-Type",
-												"value": "application/json",
-												"type": "text"
-											},
-											{
-												"key": "Authorization",
-												"value": "Bearer {{accessToken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"app.read\",\n        \"app.update\",\n        \"hosted-page-config.read\",\n        \"hosted-page-config.update\",\n        \"password-policy.read\",\n        \"password-policy.update\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"customClaims\": {},\n    \"description\": \"M2Mx\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"clientCredentials\": true\n    },\n    \"jwtSigningAlgorithm\": \"HS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [],\n    \"name\": \"M2M\",\n    \"refreshTokenLifetime\": 604800,\n    \"type\" : \"m2m\"\n}\n\n   \n\n   "
-										},
-										"url": {
-											"raw": "{{tenantApiV1Url}}/apps",
-											"host": [
-												"{{tenantApiV1Url}}"
-											],
-											"path": [
-												"apps"
-											]
-										}
-									},
-									"status": "Created",
-									"code": 201,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "X-Powered-By",
-											"value": "Express"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8"
-										},
-										{
-											"key": "Content-Length",
-											"value": "642"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"282-nruA6aCer1x6kS9ravO3/BLao7s\""
-										},
-										{
-											"key": "Date",
-											"value": "Fri, 01 Mar 2019 19:23:18 GMT"
-										},
-										{
-											"key": "Via",
-											"value": "1.1 google"
-										}
-									],
-									"cookie": [],
-									"body": "{\n    \"accessTokenLifetime\": 3600,\n    \"apiScopes\": [\n        \"app.read\",\n        \"app.update\",\n        \"hosted-page-config.read\",\n        \"hosted-page-config.update\",\n        \"password-policy.read\",\n        \"password-policy.update\"\n    ],\n    \"authorizationCodeLifetime\": 120,\n    \"clientId\": \"{{serviceAppClientId}}\",\n    \"customClaims\": {},\n    \"description\": \"M2Mx\",\n    \"domain\": \"\",\n    \"enabled\": true,\n    \"grantTypes\": {\n        \"authorizationCode\": false,\n        \"clientCredentials\": true,\n        \"password\": false,\n        \"refreshToken\": false\n    },\n    \"jwtSigningAlgorithm\": \"HS256\",\n    \"jwtTokenLifetime\": 3600,\n    \"loginRedirectUris\": [],\n    \"logoUrl\": \"\",\n    \"logoutRedirectUris\": [],\n    \"name\": \"M2M\",\n    \"refreshTokenLifetime\": 604800,\n    \"secret\": \"{{serviceAppClientSecret}}\",\n    \"type\": \"m2m\"\n}"
-								}
-							]
-						},
-						{
-							"name": "Update Web App",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "b8055a85-9dc6-4c97-abbb-3a3d7dd2febf",
-										"exec": [
-											"if (200 == responseCode.code) {",
-											"    var jsonData = JSON.parse(responseBody);",
-											"    postman.setEnvironmentVariable(\"clientId\", jsonData.clientId);",
-											"    postman.setEnvironmentVariable(\"clientSecret\", jsonData.secret);",
-											"}"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{accessToken}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "PUT",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"accessTokenLifetime\": 3600,\n  \"authorizationCodeLifetime\": 120,\n  \"customClaims\": {},\n  \"description\": \"My great food app\",\n  \"enabled\": true,\n  \"grantTypes\": {\n    \"authorizationCode\": true,\n    \"refreshToken\": true,\n    \"clientCredentials\": true,\n    \"password\" : true\n  },\n  \"jwtSigningAlgorithm\": \"HS256\",\n  \"jwtTokenLifetime\": 3600,\n  \"loginRedirectUris\": [\"http://localhost:9080/callback,http://localhost:9080/callback/non-hosted\"],\n  \"logoutRedirectUris\": [\"http://localhost:9080\"],\n  \"name\": \"New Top Foods\",\n  \"refreshTokenLifetime\": 604800,\n  \"type\": \"web\"\n}"
-								},
-								"url": {
-									"raw": "{{tenantApiV1Url}}/apps/{{client_id}}",
-									"host": [
-										"{{tenantApiV1Url}}"
-									],
-									"path": [
-										"apps",
-										"{{client_id}}"
-									]
-								},
-								"description": "**BROKEN**\nUpdates the configuration of an existing web application client"
-							},
-							"response": [
-								{
-									"name": "Update Application Client - Web",
-									"originalRequest": {
-										"method": "PUT",
-										"header": [
-											{
-												"key": "Authorization",
-												"value": "Bearer {{access_token}}",
-												"disabled": true
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json",
-												"warning": ""
-											},
-											{
-												"key": "Authorization",
-												"value": "Bearer {{accessToken}}",
-												"warning": "This is a duplicate header and will be overridden by the Authorization header generated by Postman."
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "    {\n    \t\"authorizationCodeLifetime\": 120,\n        \"accessTokenLifetime\": 3600,\n        \"apiScopes\": [\n            \"app.read\",\n            \"app.write\",\n            \"hosted-page-config.read\",\n            \"hosted-page-config.write\",\n            \"password-policy.read\",\n            \"password-policy.write\",\n            \"team-member.read\",\n            \"team-member.write\",\n            \"user.read\",\n            \"user.write\"\n        ],\n\n        \"customClaims\": {},\n        \"description\": \"My great food app\",\n        \"domain\": \"\",\n        \"enabled\": true,\n        \"grantTypes\": {\n            \"authorizationCode\": true,\n            \"refreshToken\": true\n        },\n        \"jwtSigningAlgorithm\": \"HS256\",\n        \"jwtTokenLifetime\": 3600,\n        \"loginRedirectUris\": [\n            \"http://localhost:9080/callback\"\n        ],\n        \"logoUrl\": \"\",\n        \"logoutRedirectUris\": [\n            \"http://localhost:9080/\"\n        ],\n        \"name\": \"New Top Foods\",\n        \"clientId\": \"070462ae12ec98a1e05e65e8c2148802\",\n        \"refreshTokenLifetime\": 604800,\n        \"type\": \"web\"\n        \n    }"
-										},
-										"url": {
-											"raw": "{{tenantApiV1Url}}/apps/55c52e21-f720-4c4c-9cd3-13682900a10a",
-											"host": [
-												"{{tenantApiV1Url}}"
-											],
-											"path": [
-												"apps",
-												"55c52e21-f720-4c4c-9cd3-13682900a10a"
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*",
-											"name": "Access-Control-Allow-Origin",
-											"description": "Specifies a URI that may access the resource. For requests without credentials, the server may specify '*' as a wildcard, thereby allowing any origin to access the resource."
-										},
-										{
-											"key": "Content-Length",
-											"value": "1288",
-											"name": "Content-Length",
-											"description": "The length of the response body in octets (8-bit bytes)"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8",
-											"name": "Content-Type",
-											"description": "The mime type of this content"
-										},
-										{
-											"key": "Date",
-											"value": "Fri, 05 Oct 2018 22:05:57 GMT",
-											"name": "Date",
-											"description": "The date and time that the message was sent"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"508-BaqQQ3d8qtxW9+837nCJwLGhcv0\"",
-											"name": "ETag",
-											"description": "An identifier for a specific version of a resource, often a message digest"
-										},
-										{
-											"key": "Via",
-											"value": "1.1 google",
-											"name": "Via",
-											"description": "Informs the client of proxies through which the response was sent."
-										},
-										{
-											"key": "X-Powered-By",
-											"value": "Express",
-											"name": "X-Powered-By",
-											"description": "Specifies the technology (ASP.NET, PHP, JBoss, e.g.) supporting the web application (version details are often in X-Runtime, X-Version, or X-AspNet-Version)"
-										}
-									],
-									"cookie": [
-										{
-											"expires": "Invalid Date",
-											"httpOnly": false,
-											"domain": "forgeblocks.com",
-											"path": "/",
-											"secure": false,
-											"value": "lqun1BrLOjUDf9nTxZKQM3gTt1Q.*AAJTSQACMDIAAlNLABxNRHArUGZ4TXB2MzJGMUU2dnlaczY2Y3ZVM3c9AAR0eXBlAANDVFMAAlMxAAIwMQ..*",
-											"key": "iPlanetDirectoryPro"
-										}
-									],
-									"body": "{\n  \"accessTokenLifetime\": 3600,\n  \"apiScopes\": [\n    \"app.read\",\n    \"app.update\",\n    \"hosted-page-config.read\",\n    \"hosted-page-config.update\",\n    \"password-policy.read\",\n    \"password-policy.update\",\n    \"user.read\",\n    \"user.update\"\n  ],\n  \"authorizationCodeLifetime\": 120,\n  \"clientId\": \"{{appClientId}}\",\n  \"customClaims\": {},\n  \"description\": \"My great food app\",\n  \"domain\": \"\",\n  \"enabled\": true,\n  \"grantTypes\": {\n    \"authorizationCode\": true,\n    \"clientCredentials\": true,\n    \"refreshToken\": true\n  },\n  \"jwtSigningAlgorithm\": \"HS256\",\n  \"jwtTokenLifetime\": 3600,\n  \"loginRedirectUris\": [\n    \"http://localhost:9080/callback\"\n  ],\n  \"logoUrl\": \"\",\n  \"logoutRedirectUris\": [\n    \"http://localhost:9080/\"\n  ],\n  \"name\": \"New Top Foods\",\n  \"refreshTokenLifetime\": 604800,\n  \"secret\": null,\n  \"type\": \"web\"\n}"
-								}
-							]
-						},
-						{
-							"name": "Delete app",
-							"request": {
-								"auth": {
-									"type": "noauth"
-								},
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "Authorization",
-										"value": "Bearer {{accessToken}}"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{tenantApiV1Url}}/apps/{{client_id}}",
-									"host": [
-										"{{tenantApiV1Url}}"
-									],
-									"path": [
-										"apps",
-										"{{client_id}}"
-									]
-								},
-								"description": "Deletes an app as specified by its Client ID\n"
-							},
-							"response": [
-								{
-									"name": "Delete app",
-									"originalRequest": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "Authorization",
-												"value": "Bearer {{accessToken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{tenantApiV1Url}}/apps/{{appClientId}}",
-											"host": [
-												"{{tenantApiV1Url}}"
-											],
-											"path": [
-												"apps",
-												"{{appClientId}}"
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "X-Powered-By",
-											"value": "Express"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8"
-										},
-										{
-											"key": "Content-Length",
-											"value": "3388"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"d3c-JL9cbEsCNlLO0aKhhWXavGs0XHo\""
-										},
-										{
-											"key": "Date",
-											"value": "Fri, 01 Mar 2019 19:33:37 GMT"
-										},
-										{
-											"key": "Via",
-											"value": "1.1 google"
-										}
-									],
-									"cookie": [],
-									"body": "{\n    \"_id\": \"{{appClientId}}\",\n    \"_rev\": \"-626963567\",\n    \"advancedOAuth2ClientConfig\": {\n        \"descriptions\": {\n            \"inherited\": false,\n            \"value\": [\n                \"App Descroption\"\n            ]\n        },\n        \"requestUris\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"logoUri\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"subjectType\": {\n            \"inherited\": false,\n            \"value\": \"Public\"\n        },\n        \"clientUri\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"name\": {\n            \"inherited\": false,\n            \"value\": [\n                \"\"\n            ]\n        },\n        \"contacts\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"responseTypes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"token\"\n            ]\n        },\n        \"updateAccessToken\": {\n            \"inherited\": false\n        },\n        \"mixUpMitigation\": {\n            \"inherited\": false,\n            \"value\": false\n        },\n        \"policyUri\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"sectorIdentifierUri\": {\n            \"inherited\": false\n        },\n        \"tokenEndpointAuthMethod\": {\n            \"inherited\": false,\n            \"value\": \"client_secret_basic\"\n        },\n        \"isConsentImplied\": {\n            \"inherited\": false,\n            \"value\": true\n        },\n        \"grantTypes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"client_credentials\"\n            ]\n        }\n    },\n    \"signEncOAuth2ClientConfig\": {\n        \"tokenEndpointAuthSigningAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"RS256\"\n        },\n        \"idTokenEncryptionEnabled\": {\n            \"inherited\": false,\n            \"value\": false\n        },\n        \"requestParameterSignedAlg\": {\n            \"inherited\": false\n        },\n        \"clientJwtPublicKey\": {\n            \"inherited\": false\n        },\n        \"idTokenPublicEncryptionKey\": {\n            \"inherited\": false\n        },\n        \"userinfoResponseFormat\": {\n            \"inherited\": false,\n            \"value\": \"JSON\"\n        },\n        \"publicKeyLocation\": {\n            \"inherited\": false,\n            \"value\": \"jwks_uri\"\n        },\n        \"jwkStoreCacheMissCacheTime\": {\n            \"inherited\": false,\n            \"value\": 60000\n        },\n        \"requestParameterEncryptedEncryptionAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"A128CBC-HS256\"\n        },\n        \"userinfoSignedResponseAlg\": {\n            \"inherited\": false\n        },\n        \"idTokenEncryptionAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"RSA-OAEP-256\"\n        },\n        \"requestParameterEncryptedAlg\": {\n            \"inherited\": false\n        },\n        \"jwkSet\": {\n            \"inherited\": false\n        },\n        \"idTokenEncryptionMethod\": {\n            \"inherited\": false,\n            \"value\": \"A128CBC-HS256\"\n        },\n        \"jwksCacheTimeout\": {\n            \"inherited\": false,\n            \"value\": 3600000\n        },\n        \"userinfoEncryptedResponseAlg\": {\n            \"inherited\": false\n        },\n        \"idTokenSignedResponseAlg\": {\n            \"inherited\": false,\n            \"value\": \"HS256\"\n        },\n        \"jwksUri\": {\n            \"inherited\": false,\n            \"value\": \"http://openam:80/oauth2/connect/jwk_uri\"\n        },\n        \"userinfoEncryptedResponseEncryptionAlgorithm\": {\n            \"inherited\": false,\n            \"value\": \"A128CBC-HS256\"\n        }\n    },\n    \"coreOpenIDClientConfig\": {\n        \"claims\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"clientSessionUri\": {\n            \"inherited\": false\n        },\n        \"defaultAcrValues\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"jwtTokenLifetime\": {\n            \"inherited\": false,\n            \"value\": 3600\n        },\n        \"defaultMaxAgeEnabled\": {\n            \"inherited\": false,\n            \"value\": false\n        },\n        \"defaultMaxAge\": {\n            \"inherited\": false,\n            \"value\": 600\n        },\n        \"postLogoutRedirectUri\": {\n            \"inherited\": false,\n            \"value\": []\n        }\n    },\n    \"coreOAuth2ClientConfig\": {\n        \"userpassword\": null,\n        \"userpassword-encrypted\": \"{{userPasswordEncrypted}}\",\n        \"defaultScopes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"openid\"\n            ]\n        },\n        \"refreshTokenLifetime\": {\n            \"inherited\": false,\n            \"value\": 604800\n        },\n        \"scopes\": {\n            \"inherited\": false,\n            \"value\": [\n                \"address\",\n                \"phone\",\n                \"profile\",\n                \"email\",\n                \"app.read\",\n                \"email-template.read\",\n                \"password-policy.read\",\n                \"user.reset-password\",\n                \"user.recover-username\",\n                \"user.create\",\n                \"user.read\",\n                \"user.update\"\n            ]\n        },\n        \"status\": {\n            \"inherited\": false,\n            \"value\": \"Active\"\n        },\n        \"accessTokenLifetime\": {\n            \"inherited\": false,\n            \"value\": 3600\n        },\n        \"redirectionUris\": {\n            \"inherited\": false,\n            \"value\": []\n        },\n        \"clientName\": {\n            \"inherited\": false,\n            \"value\": [\n                \"App name\"\n            ]\n        },\n        \"clientType\": {\n            \"inherited\": false,\n            \"value\": \"Confidential\"\n        },\n        \"authorizationCodeLifetime\": {\n            \"inherited\": false,\n            \"value\": 120\n        }\n    },\n    \"coreUmaClientConfig\": {\n        \"claimsRedirectionUris\": {\n            \"inherited\": false,\n            \"value\": []\n        }\n    },\n    \"_type\": {\n        \"_id\": \"OAuth2Client\",\n        \"name\": \"OAuth2 Clients\",\n        \"collection\": true\n    }\n}"
-								}
-							]
 						}
 					],
 					"description": "Configure, create, and manage applications.",
@@ -2644,7 +1848,9 @@
 									"script": {
 										"id": "4fd89a1d-1a41-4692-9c2a-a09ac9c2cbed",
 										"exec": [
-											""
+											"var jsonData = JSON.parse(responseBody);",
+											"    postman.setEnvironmentVariable(\"userName\", jsonData.userName);",
+											"    postman.setEnvironmentVariable(\"userId\", jsonData.id);"
 										],
 										"type": "text/javascript"
 									}
@@ -2672,7 +1878,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "  {\n    \"externalId\": \"701985\",\n    \"userName\": \"bjensen@example.com\",\n    \"accountVerified\": true,\n    \"name\": {\n      \"formatted\": \"Ms. Barbara J Jensen, III\",\n      \"familyName\": \"Jensen\",\n      \"givenName\": \"Barbara\",\n      \"middleName\": \"Jane\",\n      \"honorificPrefix\": \"Ms.\",\n      \"honorificSuffix\": \"III\"\n    },\n    \"displayName\": \"Babs Jensen\",\n    \"nickName\": \"Babs\",\n    \"profileUrl\": \"https://login.example.com/bjensen\",\n    \"emails\": [\n      {\n        \"value\": \"bjensen@example.com\",\n        \"type\": \"work\",\n        \"primary\": true,\n        \"verified\": true\n      },\n      {\n        \"value\": \"babs@jensen.org\",\n        \"type\": \"home\",\n        \"verified\": false\n      }\n    ],\n    \"addresses\": [\n      {\n        \"type\": \"work\",\n        \"streetAddress\": \"6925 Hollywood Blvd\",\n        \"locality\": \"Hollywood\",\n        \"region\": \"CA\",\n        \"postalCode\": \"90028\",\n        \"country\": \"US\",\n        \"formatted\": \"6925 Hollywood Blvd\\nHollywood, CA 90028 USA\",\n        \"primary\": true\n      },\n      {\n        \"type\": \"home\",\n        \"streetAddress\": \"2800 E Observatory Rd\",\n        \"locality\": \"Los Angeles\",\n        \"region\": \"CA\",\n        \"postalCode\": \"90027\",\n        \"country\": \"US\",\n        \"formatted\": \"2800 E Observatory Rd\\nLos Angeles, CA 90027 USA\"\n      }\n    ],\n    \"phoneNumbers\": [\n      {\n        \"value\": \"555-555-5555\",\n        \"type\": \"work\"\n      },\n      {\n        \"value\": \"555-555-4444\",\n        \"type\": \"mobile\"\n      }\n    ],\n    \"userType\": \"Customer\",\n    \"title\": \"Master Carpenter\",\n    \"preferredLanguage\": \"en-US\",\n    \"locale\": \"en-US\",\n    \"timezone\": \"America/Los_Angeles\",\n    \"active\": true,\n    \"password\": \"Passwordy1#\"\n  }\n"
+									"raw": "  {\n    \"externalId\": \"701985\",\n    \"userName\": \"bjensen@example.com\",\n    \"accountVerified\": true,\n    \"name\": {\n      \"formatted\": \"Ms. Barbara J Jensen, III\",\n      \"familyName\": \"Jensen\",\n      \"givenName\": \"Barbara\",\n      \"middleName\": \"Jane\",\n      \"honorificPrefix\": \"Ms.\",\n      \"honorificSuffix\": \"III\"\n    },\n    \"displayName\": \"Babs Jensen\",\n    \"nickName\": \"Babs\",\n    \"profileUrl\": \"https://login.example.com/bjensen\",\n    \"emails\": [\n      {\n        \"value\": \"bjensen@example.com\",\n        \"type\": \"work\",\n        \"primary\": true,\n        \"verified\": true\n      },\n      {\n        \"value\": \"babs@jensen.org\",\n        \"type\": \"home\",\n        \"verified\": false\n      }\n    ],\n    \"addresses\": [\n      {\n        \"type\": \"work\",\n        \"streetAddress\": \"6925 Hollywood Blvd\",\n        \"locality\": \"Hollywood\",\n        \"region\": \"CA\",\n        \"postalCode\": \"90028\",\n        \"country\": \"US\",\n        \"formatted\": \"6925 Hollywood Blvd\\nHollywood, CA 90028 USA\",\n        \"primary\": true\n      },\n      {\n        \"type\": \"home\",\n        \"streetAddress\": \"2800 E Observatory Rd\",\n        \"locality\": \"Los Angeles\",\n        \"region\": \"CA\",\n        \"postalCode\": \"90027\",\n        \"country\": \"US\",\n        \"formatted\": \"2800 E Observatory Rd\\nLos Angeles, CA 90027 USA\"\n      }\n    ],\n    \"phoneNumbers\": [\n      {\n        \"value\": \"555-555-5555\",\n        \"type\": \"work\"\n      },\n      {\n        \"value\": \"555-555-4444\",\n        \"type\": \"mobile\"\n      }\n    ],\n    \"userType\": \"Customer\",\n    \"title\": \"Master Carpenter\",\n    \"preferredLanguage\": \"en-US\",\n    \"locale\": \"en-US\",\n    \"timezone\": \"America/Los_Angeles\",\n    \"active\": true,\n    \"password\": \"{{userPassword}}\"\n  }\n"
 								},
 								"url": {
 									"raw": "{{tenantApiV1Url}}/users",
@@ -2768,6 +1974,244 @@
 							]
 						},
 						{
+							"name": "Get user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "05d1599b-0381-4624-a543-dea85637de9b",
+										"exec": [
+											"var jsonData = JSON.parse(responseBody);",
+											"postman.setEnvironmentVariable(\"userId\", jsonData.id);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{accessToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{tenantApiV1Url}}/users/{{userId}}",
+									"host": [
+										"{{tenantApiV1Url}}"
+									],
+									"path": [
+										"users",
+										"{{userId}}"
+									]
+								},
+								"description": "Retreives data for the user as specified by the `id`, as shown in the output from the Get Users REST call.\n\nUse an access_token for the web app."
+							},
+							"response": [
+								{
+									"name": "Get user",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{accessToken}}"
+											}
+										],
+										"url": {
+											"raw": "{{tenantApiV1Url}}/users/{{userId}}",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"users",
+												"{{userId}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Powered-By",
+											"value": "Express"
+										},
+										{
+											"key": "Access-Control-Allow-Origin",
+											"value": "*"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json; charset=utf-8"
+										},
+										{
+											"key": "Content-Length",
+											"value": "1276"
+										},
+										{
+											"key": "ETag",
+											"value": "W/\"4fc-yRk9ihtwFwZzUwgsP7tJ4sKqpL8\""
+										},
+										{
+											"key": "Date",
+											"value": "Mon, 04 Mar 2019 16:46:21 GMT"
+										},
+										{
+											"key": "Via",
+											"value": "1.1 google"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"accountStatus\": \"Active\",\n    \"addresses\": [\n        {\n            \"type\": \"work\",\n            \"streetAddress\": \"6925 Hollywood Blvd\",\n            \"locality\": \"Hollywood\",\n            \"region\": \"CA\",\n            \"postalCode\": \"90028\",\n            \"country\": \"US\",\n            \"formatted\": \"6925 Hollywood Blvd\\nHollywood, CA 90028 USA\",\n            \"primary\": true\n        },\n        {\n            \"type\": \"home\",\n            \"streetAddress\": \"2800 E Observatory Rd\",\n            \"locality\": \"Los Angeles\",\n            \"region\": \"CA\",\n            \"postalCode\": \"90027\",\n            \"country\": \"US\",\n            \"formatted\": \"2800 E Observatory Rd\\nLos Angeles, CA 90027 USA\"\n        }\n    ],\n    \"displayName\": \"Babs Jensen\",\n    \"emails\": [\n        {\n            \"value\": \"bjensen@example.com\",\n            \"type\": \"work\",\n            \"primary\": true,\n            \"verified\": false\n        },\n        {\n            \"value\": \"babs@jensen.org\",\n            \"type\": \"home\",\n            \"verified\": false\n        }\n    ],\n    \"id\": \"c8fe6bce-94b7-47d3-8a46-96c4dd979ff3\",\n    \"ims\": [],\n    \"locale\": \"en-US\",\n    \"name\": {\n        \"formatted\": \"Ms. Barbara J Jensen, III\",\n        \"familyName\": \"Jensen\",\n        \"givenName\": \"Barbara\",\n        \"middleName\": \"Jane\",\n        \"honorificPrefix\": \"Ms.\",\n        \"honorificSuffix\": \"III\"\n    },\n    \"nickName\": \"Babs\",\n    \"phoneNumbers\": [\n        {\n            \"value\": \"555-555-5555\",\n            \"type\": \"work\"\n        },\n        {\n            \"value\": \"555-555-4444\",\n            \"type\": \"mobile\"\n        }\n    ],\n    \"preferences\": {},\n    \"preferredLanguage\": \"en-US\",\n    \"profileUrl\": \"https://login.example.com/bjensen\",\n    \"timezone\": \"America/Los_Angeles\",\n    \"title\": \"Master Carpenter\",\n    \"userName\": \"bjensen@example.com\",\n    \"userType\": \"Customer\",\n    \"x509Certificates\": [],\n    \"meta\": {\n        \"created\": \"2019-03-04T16:44:12.334Z\",\n        \"lastModified\": \"2019-03-04T16:44:12.334Z\"\n    }\n}"
+								}
+							]
+						},
+						{
+							"name": "Update user",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "e4caebed-e3ad-4dd7-a989-39a1b2401116",
+										"exec": [
+											"var jsonData = JSON.parse(responseBody);",
+											"    postman.setEnvironmentVariable(\"userName\", jsonData.userName);",
+											"    postman.setEnvironmentVariable(\"userId\", jsonData.id);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{accessToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n   \"addresses\": [\n      {\n         \"type\": \"work\",\n         \"streetAddress\": \"6925 Hollywood Blvd\",\n         \"locality\": \"San Francisco\",\n         \"region\": \"CA\",\n         \"postalCode\": \"94703\",\n         \"country\": \"US\",\n         \"formatted\": \"6925 Hollywood Blvd\\nHollywood, CA 94703 USA\",\n         \"primary\": true\n      },\n      {\n         \"type\": \"home\",\n         \"streetAddress\": \"2800 E Observatory Rd\",\n         \"locality\": \"Los Angeles\",\n         \"region\": \"CA\",\n         \"postalCode\": \"90027\",\n         \"country\": \"US\",\n         \"formatted\": \"2800 E Observatory Rd\\nLos Angeles, CA 90027 USA\"\n      }\n   ],\n   \"emails\": [\n      {\n         \"value\": \"bjensen@example.com\",\n         \"type\": \"work\",\n         \"primary\": true,\n         \"verified\": false\n      },\n      {\n         \"value\": \"babs@jensen.org\",\n         \"type\": \"home\",\n         \"verified\": false\n      }\n   ],\n   \"name\": {\n      \"formatted\": \"Ms. Barbara J Jensen, III\",\n      \"familyName\": \"Jensen\",\n      \"givenName\": \"Barbara\",\n      \"middleName\": \"Jane\",\n      \"honorificPrefix\": \"Ms.\",\n      \"honorificSuffix\": \"III\"\n   },\n   \"phoneNumbers\": [\n      {\n         \"value\": \"555-555-5553\",\n         \"type\": \"work\"\n      },\n      {\n         \"value\": \"555-555-4444\",\n         \"type\": \"mobile\"\n      }\n   ],\n   \"accountStatus\": \"Active\"\n}"
+								},
+								"url": {
+									"raw": "{{tenantApiV1Url}}/users/{{userId}}",
+									"host": [
+										"{{tenantApiV1Url}}"
+									],
+									"path": [
+										"users",
+										"{{userId}}"
+									]
+								},
+								"description": "Updates properties for the specified user.\n"
+							},
+							"response": [
+								{
+									"name": "Update user",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n   \"addresses\":[\n      {\n         \"type\":\"home\",\n         \"streetAddress\":\"2800 W Observatory Rd, new location\",\n         \"locality\":\"Los Angeles\",\n         \"region\":\"CA\",\n         \"postalCode\":\"90026\",\n         \"country\":\"US\",\n         \"formatted\":\"2800 E Observatory Rd\\nLos Angeles, CA 90027 USA\"\n      },\n      {\n         \"type\":\"work\",\n         \"streetAddress\":\"6925 Hollywood Blvd\",\n         \"locality\":\"Hollywood\",\n         \"region\":\"CA\",\n         \"postalCode\":\"90027\",\n         \"country\":\"US\",\n         \"formatted\":\"6925 Hollywood Blvd\\nHollywood, CA 90028 USA\",\n         \"primary\":true\n      }\n   ],\n   \"emails\":[\n      {\n         \"value\":\"bjensen@example.com\",\n         \"type\":\"work\",\n         \"primary\":true,\n         \"verified\":false\n      },\n      {\n         \"value\":\"babs@jensen.org\",\n         \"type\":\"home\",\n         \"verified\":false\n      }\n   ],\n   \"name\":{\n      \"formatted\":\"Ms. Barbara J Jensen, III\",\n      \"familyName\":\"Jensen\",\n      \"givenName\":\"Barbara\",\n      \"middleName\":\"Jane\",\n      \"honorificPrefix\":\"Ms.\",\n      \"honorificSuffix\":\"III\"\n   },\n   \"phoneNumbers\":[\n      {\n         \"value\":\"555-555-5555\",\n         \"type\":\"work\"\n      },\n      {\n         \"value\":\"555-555-4444\",\n         \"type\":\"mobile\"\n      }\n   ],\n   \"accountStatus\":\"Active\"\n}"
+										},
+										"url": {
+											"raw": "{{tenantApiV1Url}}/users/{{userId}}",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"users",
+												"{{userId}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-DNS-Prefetch-Control",
+											"value": "off"
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "SAMEORIGIN"
+										},
+										{
+											"key": "Strict-Transport-Security",
+											"value": "max-age=15552000; includeSubDomains"
+										},
+										{
+											"key": "X-Download-Options",
+											"value": "noopen"
+										},
+										{
+											"key": "X-Content-Type-Options",
+											"value": "nosniff"
+										},
+										{
+											"key": "X-XSS-Protection",
+											"value": "1; mode=block"
+										},
+										{
+											"key": "Access-Control-Allow-Origin",
+											"value": "*"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json; charset=utf-8"
+										},
+										{
+											"key": "Content-Length",
+											"value": "1290"
+										},
+										{
+											"key": "ETag",
+											"value": "W/\"50a-DI928oF7rtfaGdJRKlF8kpc7Ux8\""
+										},
+										{
+											"key": "Date",
+											"value": "Wed, 12 Jun 2019 17:50:01 GMT"
+										},
+										{
+											"key": "Via",
+											"value": "1.1 google"
+										},
+										{
+											"key": "Alt-Svc",
+											"value": "clear"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"accountStatus\": \"Active\",\n    \"addresses\": [\n        {\n            \"type\": \"work\",\n            \"streetAddress\": \"6925 Hollywood Blvd\",\n            \"locality\": \"Hollywood\",\n            \"region\": \"CA\",\n            \"postalCode\": \"90027\",\n            \"country\": \"US\",\n            \"formatted\": \"6925 Hollywood Blvd\\nHollywood, CA 90028 USA\",\n            \"primary\": true\n        },\n        {\n            \"type\": \"home\",\n            \"streetAddress\": \"2800 W Observatory Rd, new location\",\n            \"locality\": \"Los Angeles\",\n            \"region\": \"CA\",\n            \"postalCode\": \"90026\",\n            \"country\": \"US\",\n            \"formatted\": \"2800 E Observatory Rd\\nLos Angeles, CA 90027 USA\"\n        }\n    ],\n    \"displayName\": \"Babs Jensen\",\n    \"emails\": [\n        {\n            \"value\": \"bjensen@example.com\",\n            \"type\": \"work\",\n            \"primary\": true,\n            \"verified\": false\n        },\n        {\n            \"value\": \"babs@jensen.org\",\n            \"type\": \"home\",\n            \"verified\": false\n        }\n    ],\n    \"id\": \"671d77dc-3171-41cd-a7b4-fc8c80977794\",\n    \"ims\": [],\n    \"locale\": \"en-US\",\n    \"name\": {\n        \"formatted\": \"Ms. Barbara J Jensen, III\",\n        \"familyName\": \"Jensen\",\n        \"givenName\": \"Barbara\",\n        \"middleName\": \"Jane\",\n        \"honorificPrefix\": \"Ms.\",\n        \"honorificSuffix\": \"III\"\n    },\n    \"nickName\": \"Babs\",\n    \"phoneNumbers\": [\n        {\n            \"value\": \"555-555-5555\",\n            \"type\": \"work\"\n        },\n        {\n            \"value\": \"555-555-4444\",\n            \"type\": \"mobile\"\n        }\n    ],\n    \"preferences\": {},\n    \"preferredLanguage\": \"en-US\",\n    \"profileUrl\": \"https://login.example.com/bjensen\",\n    \"timezone\": \"America/Los_Angeles\",\n    \"title\": \"Master Carpenter\",\n    \"userName\": \"bjensen@example.com\",\n    \"userType\": \"Customer\",\n    \"x509Certificates\": [],\n    \"meta\": {\n        \"created\": \"2019-06-12T16:47:59.397Z\",\n        \"lastModified\": \"2019-06-12T17:50:00.975Z\"\n    }\n}"
+								}
+							]
+						},
+						{
 							"name": "Get users",
 							"event": [
 								{
@@ -2775,8 +2219,7 @@
 									"script": {
 										"id": "570678be-7344-4365-83fa-236eeff8b588",
 										"exec": [
-											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"userId\", jsonData.id);"
+											""
 										],
 										"type": "text/javascript"
 									}
@@ -2802,10 +2245,6 @@
 										"value": "application/x-www-form-urlencoded"
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{tenantApiV1Url}}/users",
 									"host": [
@@ -2823,10 +2262,6 @@
 									"originalRequest": {
 										"method": "GET",
 										"header": [],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{tenantApiV1Url}}/users",
 											"host": [
@@ -2876,7 +2311,7 @@
 							]
 						},
 						{
-							"name": "Get users with conditions",
+							"name": "Get users with search filter",
 							"event": [
 								{
 									"listen": "test",
@@ -2910,10 +2345,6 @@
 										"value": "application/x-www-form-urlencoded"
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{tenantApiV1Url}}/users?{{parameter}}={{userProperty}}%20{{comparator}}%20%22{{value}}%22",
 									"host": [
@@ -2949,10 +2380,6 @@
 												"type": "text"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "http://api.TENANT_NAME.forgeblocks.com/users?filter=userName%20eq%20%22bjensen@example.com%22",
 											"protocol": "http",
@@ -3032,781 +2459,6 @@
 							]
 						},
 						{
-							"name": "Get user",
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{accessToken}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "GET",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{tenantApiV1Url}}/users/{{userId}}",
-									"host": [
-										"{{tenantApiV1Url}}"
-									],
-									"path": [
-										"users",
-										"{{userId}}"
-									]
-								},
-								"description": "Retreives data for the user as specified by the `id`, as shown in the output from the Get Users REST call.\n\nUse an access_token for the web app."
-							},
-							"response": [
-								{
-									"name": "Get user",
-									"originalRequest": {
-										"method": "GET",
-										"header": [
-											{
-												"key": "Authorization",
-												"value": "Bearer {{accessToken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{tenantApiV1Url}}/users/{{userId}}",
-											"host": [
-												"{{tenantApiV1Url}}"
-											],
-											"path": [
-												"users",
-												"{{userId}}"
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "X-Powered-By",
-											"value": "Express"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8"
-										},
-										{
-											"key": "Content-Length",
-											"value": "1276"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"4fc-yRk9ihtwFwZzUwgsP7tJ4sKqpL8\""
-										},
-										{
-											"key": "Date",
-											"value": "Mon, 04 Mar 2019 16:46:21 GMT"
-										},
-										{
-											"key": "Via",
-											"value": "1.1 google"
-										}
-									],
-									"cookie": [],
-									"body": "{\n    \"accountStatus\": \"Active\",\n    \"addresses\": [\n        {\n            \"type\": \"work\",\n            \"streetAddress\": \"6925 Hollywood Blvd\",\n            \"locality\": \"Hollywood\",\n            \"region\": \"CA\",\n            \"postalCode\": \"90028\",\n            \"country\": \"US\",\n            \"formatted\": \"6925 Hollywood Blvd\\nHollywood, CA 90028 USA\",\n            \"primary\": true\n        },\n        {\n            \"type\": \"home\",\n            \"streetAddress\": \"2800 E Observatory Rd\",\n            \"locality\": \"Los Angeles\",\n            \"region\": \"CA\",\n            \"postalCode\": \"90027\",\n            \"country\": \"US\",\n            \"formatted\": \"2800 E Observatory Rd\\nLos Angeles, CA 90027 USA\"\n        }\n    ],\n    \"displayName\": \"Babs Jensen\",\n    \"emails\": [\n        {\n            \"value\": \"bjensen@example.com\",\n            \"type\": \"work\",\n            \"primary\": true,\n            \"verified\": false\n        },\n        {\n            \"value\": \"babs@jensen.org\",\n            \"type\": \"home\",\n            \"verified\": false\n        }\n    ],\n    \"id\": \"c8fe6bce-94b7-47d3-8a46-96c4dd979ff3\",\n    \"ims\": [],\n    \"locale\": \"en-US\",\n    \"name\": {\n        \"formatted\": \"Ms. Barbara J Jensen, III\",\n        \"familyName\": \"Jensen\",\n        \"givenName\": \"Barbara\",\n        \"middleName\": \"Jane\",\n        \"honorificPrefix\": \"Ms.\",\n        \"honorificSuffix\": \"III\"\n    },\n    \"nickName\": \"Babs\",\n    \"phoneNumbers\": [\n        {\n            \"value\": \"555-555-5555\",\n            \"type\": \"work\"\n        },\n        {\n            \"value\": \"555-555-4444\",\n            \"type\": \"mobile\"\n        }\n    ],\n    \"preferences\": {},\n    \"preferredLanguage\": \"en-US\",\n    \"profileUrl\": \"https://login.example.com/bjensen\",\n    \"timezone\": \"America/Los_Angeles\",\n    \"title\": \"Master Carpenter\",\n    \"userName\": \"bjensen@example.com\",\n    \"userType\": \"Customer\",\n    \"x509Certificates\": [],\n    \"meta\": {\n        \"created\": \"2019-03-04T16:44:12.334Z\",\n        \"lastModified\": \"2019-03-04T16:44:12.334Z\"\n    }\n}"
-								}
-							]
-						},
-						{
-							"name": "Get self",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "8f89d852-47f4-4bbf-9ba7-e74309887290",
-										"exec": [
-											"var jsonData = JSON.parse(responseBody);",
-											"postman.setEnvironmentVariable(\"userId\", jsonData.id);"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{accessToken}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "GET",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{tenantApiV1Url}}/me",
-									"host": [
-										"{{tenantApiV1Url}}"
-									],
-									"path": [
-										"me"
-									]
-								},
-								"description": "Retreives data for the user who is currently logged in."
-							},
-							"response": [
-								{
-									"name": "Get self",
-									"originalRequest": {
-										"method": "GET",
-										"header": [
-											{
-												"key": "Authorization",
-												"value": "Bearer {{userAccessToken}}",
-												"type": "text"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{tenantApiV1Url}}/me",
-											"host": [
-												"{{tenantApiV1Url}}"
-											],
-											"path": [
-												"me"
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "X-Powered-By",
-											"value": "Express"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8"
-										},
-										{
-											"key": "Content-Length",
-											"value": "1276"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"4fc-Di5I1QtATSzHB/r1o0+ZyJM0Tog\""
-										},
-										{
-											"key": "Date",
-											"value": "Thu, 07 Mar 2019 05:46:55 GMT"
-										},
-										{
-											"key": "Via",
-											"value": "1.1 google"
-										}
-									],
-									"cookie": [],
-									"body": "{\n    \"accountStatus\": \"Active\",\n    \"addresses\": [\n        {\n            \"type\": \"work\",\n            \"streetAddress\": \"6925 Hollywood Blvd\",\n            \"locality\": \"Hollywood\",\n            \"region\": \"CA\",\n            \"postalCode\": \"90028\",\n            \"country\": \"US\",\n            \"formatted\": \"6925 Hollywood Blvd\\nHollywood, CA 90028 USA\",\n            \"primary\": true\n        },\n        {\n            \"type\": \"home\",\n            \"streetAddress\": \"2800 E Observatory Rd\",\n            \"locality\": \"Los Angeles\",\n            \"region\": \"CA\",\n            \"postalCode\": \"90027\",\n            \"country\": \"US\",\n            \"formatted\": \"2800 E Observatory Rd\\nLos Angeles, CA 90027 USA\"\n        }\n    ],\n    \"displayName\": \"Babs Jensen\",\n    \"emails\": [\n        {\n            \"value\": \"bjensen@example.com\",\n            \"type\": \"work\",\n            \"primary\": true,\n            \"verified\": false\n        },\n        {\n            \"value\": \"babs@jensen.org\",\n            \"type\": \"home\",\n            \"verified\": false\n        }\n    ],\n    \"id\": \"{{userId}}\",\n    \"ims\": [],\n    \"locale\": \"en-US\",\n    \"name\": {\n        \"formatted\": \"Ms. Barbara J Jensen, III\",\n        \"familyName\": \"Jensen\",\n        \"givenName\": \"Barbara\",\n        \"middleName\": \"Jane\",\n        \"honorificPrefix\": \"Ms.\",\n        \"honorificSuffix\": \"III\"\n    },\n    \"nickName\": \"Babs\",\n    \"phoneNumbers\": [\n        {\n            \"value\": \"555-555-5555\",\n            \"type\": \"work\"\n        },\n        {\n            \"value\": \"555-555-4444\",\n            \"type\": \"mobile\"\n        }\n    ],\n    \"preferences\": {},\n    \"preferredLanguage\": \"en-US\",\n    \"profileUrl\": \"https://login.example.com/bjensen\",\n    \"timezone\": \"America/Los_Angeles\",\n    \"title\": \"Master Carpenter\",\n    \"userName\": \"bjensen@example.com\",\n    \"userType\": \"Customer\",\n    \"x509Certificates\": [],\n    \"meta\": {\n        \"created\": \"2019-03-06T20:59:49.510Z\",\n        \"lastModified\": \"2019-03-06T20:59:49.510Z\"\n    }\n}"
-								}
-							]
-						},
-						{
-							"name": "Update Self",
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{userAccessToken}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "PUT",
-								"header": [
-									{
-										"key": "Content-Type",
-										"name": "Content-Type",
-										"value": "application/json",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"name\": {\n    \"familyName\": \"New LastName\"\n  }\n}"
-								},
-								"url": {
-									"raw": "{{tenantApiV1Url}}/me",
-									"host": [
-										"{{tenantApiV1Url}}"
-									],
-									"path": [
-										"me"
-									]
-								},
-								"description": "**BROKEN** Can not updates attributes as self.  POST AND PATCH Lead to 404.  I would think that a patch is more appropriate then a POST for this type of user who wishes to update some information about themselves.\n\n<!DOCTYPE html>\n<html lang=\"en\">\n    <head>\n        <meta charset=\"utf-8\">\n        <title>Error</title>\n    </head>\n    <body>\n        <pre>Cannot PATCH /v1/me</pre>\n    </body>\n</html>"
-							},
-							"response": [
-								{
-									"name": "Update self",
-									"originalRequest": {
-										"method": "PUT",
-										"header": [
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "Authorization",
-												"value": "Bearer {{userAccessToken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n  \"name\": {\n    \"familyName\": \"New LastName\"\n  }\n}"
-										},
-										"url": {
-											"raw": "{{tenantApiV1Url}}/me",
-											"host": [
-												"{{tenantApiV1Url}}"
-											],
-											"path": [
-												"me"
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*",
-											"name": "Access-Control-Allow-Origin",
-											"description": "Specifies a URI that may access the resource. For requests without credentials, the server may specify '*' as a wildcard, thereby allowing any origin to access the resource."
-										},
-										{
-											"key": "Content-Length",
-											"value": "233",
-											"name": "Content-Length",
-											"description": "The length of the response body in octets (8-bit bytes)"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8",
-											"name": "Content-Type",
-											"description": "The mime type of this content"
-										},
-										{
-											"key": "Date",
-											"value": "Fri, 05 Oct 2018 21:38:06 GMT",
-											"name": "Date",
-											"description": "The date and time that the message was sent"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"e9-dLofw1HEsQgP4oG09bpOarZgqrI\"",
-											"name": "ETag",
-											"description": "An identifier for a specific version of a resource, often a message digest"
-										},
-										{
-											"key": "Via",
-											"value": "1.1 google",
-											"name": "Via",
-											"description": "Informs the client of proxies through which the response was sent."
-										},
-										{
-											"key": "X-Powered-By",
-											"value": "Express",
-											"name": "X-Powered-By",
-											"description": "Specifies the technology (ASP.NET, PHP, JBoss, e.g.) supporting the web application (version details are often in X-Runtime, X-Version, or X-AspNet-Version)"
-										}
-									],
-									"cookie": [
-										{
-											"expires": "Invalid Date",
-											"httpOnly": false,
-											"domain": "forgeblocks.com",
-											"path": "/",
-											"secure": false,
-											"value": "lqun1BrLOjUDf9nTxZKQM3gTt1Q.*AAJTSQACMDIAAlNLABxNRHArUGZ4TXB2MzJGMUU2dnlaczY2Y3ZVM3c9AAR0eXBlAANDVFMAAlMxAAIwMQ..*",
-											"key": "iPlanetDirectoryPro"
-										}
-									],
-									"body": "{\n    \"active\": true,\n    \"addresses\": [],\n    \"emails\": [\n        {\n            \"value\": \"test1@test.com\"\n        }\n    ],\n    \"id\": \"{{userId}}\",\n    \"name\": {\n        \"familyName\": \"New LastName\",\n        \"givenName\": \"test1\"\n    },\n    \"phoneNumbers\": [\n        {\n            \"value\": \"123-456-7890\"\n        }\n    ],\n    \"userName\": \"demouser\"\n}"
-								}
-							]
-						},
-						{
-							"name": "Update self password",
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{userAccessToken}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n\t\"newPassword\": \"1!!!Password!!!1\",\n\t\"oldPassword\": \"Passwordy1#\"\n}"
-								},
-								"url": {
-									"raw": "{{tenantApiV1Url}}/me/update-password",
-									"host": [
-										"{{tenantApiV1Url}}"
-									],
-									"path": [
-										"me",
-										"update-password"
-									]
-								}
-							},
-							"response": [
-								{
-									"name": "Update self password",
-									"originalRequest": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "Authorization",
-												"value": "Bearer {{userAccessToken}}",
-												"type": "text"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n\t\"newPassword\": \"1!!!Password!!!1\",\n\t\"oldPassword\": \"Passwordy1!\"\n}"
-										},
-										"url": {
-											"raw": "{{tenantApiV1Url}}/me/update-password",
-											"host": [
-												"{{tenantApiV1Url}}"
-											],
-											"path": [
-												"me",
-												"update-password"
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "X-Powered-By",
-											"value": "Express"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8"
-										},
-										{
-											"key": "Content-Length",
-											"value": "1276"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"4fc-1chtSlPpp05kbKQR3Lztcm7AkKU\""
-										},
-										{
-											"key": "Date",
-											"value": "Thu, 07 Mar 2019 17:23:11 GMT"
-										},
-										{
-											"key": "Via",
-											"value": "1.1 google"
-										}
-									],
-									"cookie": [],
-									"body": "{\n    \"accountStatus\": \"Active\",\n    \"addresses\": [\n        {\n            \"type\": \"work\",\n            \"streetAddress\": \"6925 Hollywood Blvd\",\n            \"locality\": \"Hollywood\",\n            \"region\": \"CA\",\n            \"postalCode\": \"90028\",\n            \"country\": \"US\",\n            \"formatted\": \"6925 Hollywood Blvd\\nHollywood, CA 90028 USA\",\n            \"primary\": true\n        },\n        {\n            \"type\": \"home\",\n            \"streetAddress\": \"2800 E Observatory Rd\",\n            \"locality\": \"Los Angeles\",\n            \"region\": \"CA\",\n            \"postalCode\": \"90027\",\n            \"country\": \"US\",\n            \"formatted\": \"2800 E Observatory Rd\\nLos Angeles, CA 90027 USA\"\n        }\n    ],\n    \"displayName\": \"Babs Jensen\",\n    \"emails\": [\n        {\n            \"value\": \"bjensen@example.com\",\n            \"type\": \"work\",\n            \"primary\": true,\n            \"verified\": false\n        },\n        {\n            \"value\": \"babs@jensen.org\",\n            \"type\": \"home\",\n            \"verified\": false\n        }\n    ],\n    \"id\": \"{{userId}}\",\n    \"ims\": [],\n    \"locale\": \"en-US\",\n    \"name\": {\n        \"formatted\": \"Ms. Barbara J Jensen, III\",\n        \"familyName\": \"Jensen\",\n        \"givenName\": \"Barbara\",\n        \"middleName\": \"Jane\",\n        \"honorificPrefix\": \"Ms.\",\n        \"honorificSuffix\": \"III\"\n    },\n    \"nickName\": \"Babs\",\n    \"phoneNumbers\": [\n        {\n            \"value\": \"555-555-5555\",\n            \"type\": \"work\"\n        },\n        {\n            \"value\": \"555-555-4444\",\n            \"type\": \"mobile\"\n        }\n    ],\n    \"preferences\": {},\n    \"preferredLanguage\": \"en-US\",\n    \"profileUrl\": \"https://login.example.com/bjensen\",\n    \"timezone\": \"America/Los_Angeles\",\n    \"title\": \"Master Carpenter\",\n    \"userName\": \"bjensen@example.com\",\n    \"userType\": \"Customer\",\n    \"x509Certificates\": [],\n    \"meta\": {\n        \"created\": \"2019-03-06T20:59:49.510Z\",\n        \"lastModified\": \"2019-03-07T17:23:11.235Z\"\n    }\n}"
-								}
-							]
-						},
-						{
-							"name": "Update user",
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{userAccessToken}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "PATCH",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n\t\"phoneNumbers\": [\n\t   {\n\t     \"value\":\"123-456-7890\" \n       }\n\t ]\t\n}"
-								},
-								"url": {
-									"raw": "{{tenantApiV1Url}}/users/{{userId}}",
-									"host": [
-										"{{tenantApiV1Url}}"
-									],
-									"path": [
-										"users",
-										"{{userId}}"
-									]
-								},
-								"description": "Updates sepecified properties of the user. Returns the updated user profile."
-							},
-							"response": [
-								{
-									"name": "Update user",
-									"originalRequest": {
-										"method": "PATCH",
-										"header": [
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											},
-											{
-												"key": "Authorization",
-												"value": "Bearer {{accessToken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": "{\n\t\"phoneNumbers\": [\n\t   {\n\t     \"value\":\"123-456-7890\" \n       }\n\t ]\t\n}"
-										},
-										"url": {
-											"raw": "{{tenantApiV1Url}}/users/{{id}}",
-											"host": [
-												"{{tenantApiV1Url}}"
-											],
-											"path": [
-												"users",
-												"{{id}}"
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*",
-											"name": "Access-Control-Allow-Origin",
-											"description": "Specifies a URI that may access the resource. For requests without credentials, the server may specify '*' as a wildcard, thereby allowing any origin to access the resource."
-										},
-										{
-											"key": "Content-Length",
-											"value": "234",
-											"name": "Content-Length",
-											"description": "The length of the response body in octets (8-bit bytes)"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8",
-											"name": "Content-Type",
-											"description": "The mime type of this content"
-										},
-										{
-											"key": "Date",
-											"value": "Fri, 05 Oct 2018 13:59:48 GMT",
-											"name": "Date",
-											"description": "The date and time that the message was sent"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"ea-4/t+V9rqbfCtK95V9fe+O1zfWXQ\"",
-											"name": "ETag",
-											"description": "An identifier for a specific version of a resource, often a message digest"
-										},
-										{
-											"key": "Via",
-											"value": "1.1 google",
-											"name": "Via",
-											"description": "Informs the client of proxies through which the response was sent."
-										},
-										{
-											"key": "X-Powered-By",
-											"value": "Express",
-											"name": "X-Powered-By",
-											"description": "Specifies the technology (ASP.NET, PHP, JBoss, e.g.) supporting the web application (version details are often in X-Runtime, X-Version, or X-AspNet-Version)"
-										}
-									],
-									"cookie": [],
-									"body": "{\n    \"active\": true,\n    \"addresses\": [],\n    \"emails\": [\n        {\n            \"value\": \"test@test.com\"\n        }\n    ],\n    \"id\": \"{{userId}}\",\n    \"name\": {\n        \"familyName\": \"User\",\n        \"givenName\": \"Demo\"\n    },\n    \"phoneNumbers\": [\n        {\n            \"value\": \"123-456-7890\"\n        }\n    ],\n    \"userName\": \"demouser\"\n}"
-								}
-							]
-						},
-						{
-							"name": "Update user",
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{userAccessToken}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "PUT",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "  {\n    \"externalId\": \"701985\",\n    \"accountVerified\": true,\n    \"name\": {\n      \"formatted\": \"Ms. Barbara J Jensen, III\",\n      \"familyName\": \"Jensen-updated\",\n      \"givenName\": \"Barbara-updated\",\n      \"middleName\": \"Jane-updated\",\n      \"honorificPrefix\": \"Ms.\",\n      \"honorificSuffix\": \"III\"\n    },\n    \"displayName\": \"Babs Jensen\",\n    \"nickName\": \"Babs\",\n    \"profileUrl\": \"https://login.example.com/bjensen\",\n    \"emails\": [\n      {\n        \"value\": \"bjensen@example.com\",\n        \"type\": \"work\",\n        \"primary\": true,\n        \"verified\": true\n      },\n      {\n        \"value\": \"babs@jensen.org\",\n        \"type\": \"home\",\n        \"verified\": false\n      }\n    ],\n    \"addresses\": [\n      {\n        \"type\": \"work\",\n        \"streetAddress\": \"6925 Hollywood Blvd\",\n        \"locality\": \"Hollywood\",\n        \"region\": \"CA\",\n        \"postalCode\": \"90028\",\n        \"country\": \"USA\",\n        \"formatted\": \"6925 Hollywood Blvd\\nHollywood, CA 90028 USA\",\n        \"primary\": true\n      },\n      {\n        \"type\": \"home\",\n        \"streetAddress\": \"2800 E Observatory Rd\",\n        \"locality\": \"Los Angeles\",\n        \"region\": \"CA\",\n        \"postalCode\": \"90027\",\n        \"country\": \"USA\",\n        \"formatted\": \"2800 E Observatory Rd\\nLos Angeles, CA 90027 USA\"\n      }\n    ],\n    \"phoneNumbers\": [\n      {\n        \"value\": \"555-555-5555\",\n        \"type\": \"work\"\n      },\n      {\n        \"value\": \"555-555-4444\",\n        \"type\": \"mobile\"\n      }\n    ],\n    \"userType\": \"Customer\",\n    \"title\": \"Master Carpenter\",\n    \"preferredLanguage\": \"en-US\",\n    \"locale\": \"en-US\",\n    \"timezone\": \"America/Los_Angeles\",\n    \"active\": true,\n    \"password\": \"Passwordy1!\"\n  }\n\n"
-								},
-								"url": {
-									"raw": "{{tenantApiV1Url}}/users/{{userId}}",
-									"host": [
-										"{{tenantApiV1Url}}"
-									],
-									"path": [
-										"users",
-										"{{userId}}"
-									]
-								},
-								"description": "Updates properties for the specified user.\n"
-							},
-							"response": [
-								{
-									"name": "Update user",
-									"originalRequest": {
-										"method": "PUT",
-										"header": [
-											{
-												"key": "Authorization",
-												"value": "Bearer {{userAccessToken}} "
-											},
-											{
-												"key": "Content-Type",
-												"value": "application/json"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{tenantApiV1Url}}/users/{{id}}",
-											"host": [
-												"{{tenantApiV1Url}}"
-											],
-											"path": [
-												"users",
-												"{{id}}"
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*",
-											"name": "Access-Control-Allow-Origin",
-											"description": "Specifies a URI that may access the resource. For requests without credentials, the server may specify '*' as a wildcard, thereby allowing any origin to access the resource."
-										},
-										{
-											"key": "Content-Length",
-											"value": "226",
-											"name": "Content-Length",
-											"description": "The length of the response body in octets (8-bit bytes)"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8",
-											"name": "Content-Type",
-											"description": "The mime type of this content"
-										},
-										{
-											"key": "Date",
-											"value": "Fri, 05 Oct 2018 21:35:22 GMT",
-											"name": "Date",
-											"description": "The date and time that the message was sent"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"e2-XFuUPF/DW0HGTfCc4wMb3kPo+3I\"",
-											"name": "ETag",
-											"description": "An identifier for a specific version of a resource, often a message digest"
-										},
-										{
-											"key": "Via",
-											"value": "1.1 google",
-											"name": "Via",
-											"description": "Informs the client of proxies through which the response was sent."
-										},
-										{
-											"key": "X-Powered-By",
-											"value": "Express",
-											"name": "X-Powered-By",
-											"description": "Specifies the technology (ASP.NET, PHP, JBoss, e.g.) supporting the web application (version details are often in X-Runtime, X-Version, or X-AspNet-Version)"
-										}
-									],
-									"cookie": [
-										{
-											"expires": "Invalid Date",
-											"httpOnly": false,
-											"domain": "forgeblocks.com",
-											"path": "/",
-											"secure": false,
-											"value": "lqun1BrLOjUDf9nTxZKQM3gTt1Q.*AAJTSQACMDIAAlNLABxNRHArUGZ4TXB2MzJGMUU2dnlaczY2Y3ZVM3c9AAR0eXBlAANDVFMAAlMxAAIwMQ..*",
-											"key": "iPlanetDirectoryPro"
-										}
-									],
-									"body": "{\n  \"active\": true,\n  \"addresses\": [],\n  \"emails\": [\n    {\n      \"value\": \"test1@test.com\"\n    }\n  ],\n  \"id\": \"{{userId}}\",\n  \"name\": {\n    \"familyName\": \"test1\",\n    \"givenName\": \"test1\"\n  },\n  \"phoneNumbers\": [\n    {\n      \"value\": \"123-456-7890\"\n    }\n  ],\n  \"userName\": \"demouser\"\n}"
-								}
-							]
-						},
-						{
-							"name": "Delete user",
-							"request": {
-								"auth": {
-									"type": "bearer",
-									"bearer": [
-										{
-											"key": "token",
-											"value": "{{userAccessToken}}",
-											"type": "string"
-										}
-									]
-								},
-								"method": "DELETE",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{tenantApiV1Url}}/users/{{userId}}",
-									"host": [
-										"{{tenantApiV1Url}}"
-									],
-									"path": [
-										"users",
-										"{{userId}}"
-									]
-								},
-								"description": "Deletes the user as specified by {{userId}}.  Returns the profile of the deleted user."
-							},
-							"response": [
-								{
-									"name": "Delete user",
-									"originalRequest": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "Authorization",
-												"value": "Bearer {{accessToken}}"
-											}
-										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
-										"url": {
-											"raw": "{{tenantApiV1Url}}/users/{{userId}}",
-											"host": [
-												"{{tenantApiV1Url}}"
-											],
-											"path": [
-												"users",
-												"{{userId}}"
-											]
-										}
-									},
-									"status": "OK",
-									"code": 200,
-									"_postman_previewlanguage": "json",
-									"header": [
-										{
-											"key": "X-Powered-By",
-											"value": "Express"
-										},
-										{
-											"key": "Access-Control-Allow-Origin",
-											"value": "*"
-										},
-										{
-											"key": "Content-Type",
-											"value": "application/json; charset=utf-8"
-										},
-										{
-											"key": "Content-Length",
-											"value": "409"
-										},
-										{
-											"key": "ETag",
-											"value": "W/\"199-s1GTnRHveklsUqoeoZikRh473Ko\""
-										},
-										{
-											"key": "Date",
-											"value": "Thu, 28 Feb 2019 22:01:01 GMT"
-										},
-										{
-											"key": "Via",
-											"value": "1.1 google"
-										}
-									],
-									"cookie": [],
-									"body": "{\n    \"accountStatus\": \"Active\",\n    \"addresses\": [],\n    \"displayName\": \"\",\n    \"emails\": [\n        {\n            \"value\": \"ea.cloud@forgerock.com\",\n            \"verified\": false\n        }\n    ],\n    \"id\": \"{{userId}}\",\n    \"ims\": [],\n    \"locale\": \"\",\n    \"name\": {\n        \"familyName\": \"user\",\n        \"givenName\": \"demo\"\n    },\n    \"nickName\": \"\",\n    \"phoneNumbers\": [],\n    \"preferences\": {},\n    \"preferredLanguage\": \"\",\n    \"profileUrl\": \"\",\n    \"timezone\": \"\",\n    \"title\": \"\",\n    \"userName\": \"demouser\",\n    \"userType\": \"\",\n    \"x509Certificates\": []\n}"
-								}
-							]
-						},
-						{
 							"name": "Update password",
 							"request": {
 								"auth": {
@@ -3814,12 +2466,12 @@
 									"bearer": [
 										{
 											"key": "token",
-											"value": "{{userAccessToken}}",
+											"value": "{{accessToken}}",
 											"type": "string"
 										}
 									]
 								},
-								"method": "POST",
+								"method": "PUT",
 								"header": [
 									{
 										"key": "Content-Type",
@@ -3828,19 +2480,19 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"oldPassword\": \"Passw0rd#\",\n\t\"newPassword\": \"newPassword0!changed\"\n}"
+									"raw": "{\n   \"emails\": [\n      {\n         \"value\": \"bjensen@example.com\"\n      }\n   ],\n   \"name\": {\n      \"familyName\": \"Jensen\",\n      \"givenName\": \"Barbara\"\n   },\n   \"password\": \"Passw0rd#\"\n}"
 								},
 								"url": {
-									"raw": "{{tenantApiV1Url}}/users/{{userId}}/update-password",
+									"raw": "{{tenantApiV1Url}}/users/{{userId}}",
 									"host": [
 										"{{tenantApiV1Url}}"
 									],
 									"path": [
 										"users",
-										"{{userId}}",
-										"update-password"
+										"{{userId}}"
 									]
-								}
+								},
+								"description": "A simplified form of the PUT Update user REST call, with minimum required input."
 							},
 							"response": []
 						},
@@ -3864,7 +2516,7 @@
 									"bearer": [
 										{
 											"key": "token",
-											"value": "{{userAccessToken}}",
+											"value": "{{accessToken}}",
 											"type": "string"
 										}
 									]
@@ -3960,34 +2612,35 @@
 							"name": "Reset Password with Token",
 							"request": {
 								"auth": {
-									"type": "noauth"
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{accessToken}}",
+											"type": "string"
+										}
+									]
 								},
 								"method": "POST",
 								"header": [
 									{
 										"key": "Content-Type",
 										"value": "application/json"
-									},
-									{
-										"key": "Authorization",
-										"type": "text",
-										"value": "Bearer {{userAccessToken}}",
-										"warning": "This is a duplicate header and will be overridden by the Authorization header generated by Postman."
 									}
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"email\": \"bjensen@example.com\",\n\t\"userName\": \"bjensen@example.com\"\n}"
+									"raw": "{\n\t\"destinationUrl\": \"http://your-password-reset.com\",\n\t\"email\": \"bjensen@example.com\",\n\t\"userName\": \"bjensen@example.com\"\n}"
 								},
 								"url": {
-									"raw": "{{tenantApiV1Url}}/users/reset-password/{{passwordResetToken}}",
+									"raw": "{{tenantApiV1Url}}/users/reset-password/",
 									"host": [
 										"{{tenantApiV1Url}}"
 									],
 									"path": [
 										"users",
 										"reset-password",
-										"{{passwordResetToken}}"
+										""
 									]
 								},
 								"description": "Resets a user password.  Requres a password reset token generated by Request Password Reset Token API call."
@@ -4071,7 +2724,7 @@
 									"bearer": [
 										{
 											"key": "token",
-											"value": "{{userAccessToken}}",
+											"value": "{{accessToken}}",
 											"type": "string"
 										}
 									]
@@ -4171,6 +2824,101 @@
 									"body": "{\n    \"success\": true\n}"
 								}
 							]
+						},
+						{
+							"name": "Delete user",
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{accessToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "DELETE",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{tenantApiV1Url}}/users/{{userId}}",
+									"host": [
+										"{{tenantApiV1Url}}"
+									],
+									"path": [
+										"users",
+										"{{userId}}"
+									]
+								},
+								"description": "Deletes the user as specified by {{userId}}.  Returns the profile of the deleted user."
+							},
+							"response": [
+								{
+									"name": "Delete user",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{accessToken}}"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{tenantApiV1Url}}/users/{{userId}}",
+											"host": [
+												"{{tenantApiV1Url}}"
+											],
+											"path": [
+												"users",
+												"{{userId}}"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Powered-By",
+											"value": "Express"
+										},
+										{
+											"key": "Access-Control-Allow-Origin",
+											"value": "*"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json; charset=utf-8"
+										},
+										{
+											"key": "Content-Length",
+											"value": "409"
+										},
+										{
+											"key": "ETag",
+											"value": "W/\"199-s1GTnRHveklsUqoeoZikRh473Ko\""
+										},
+										{
+											"key": "Date",
+											"value": "Thu, 28 Feb 2019 22:01:01 GMT"
+										},
+										{
+											"key": "Via",
+											"value": "1.1 google"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"accountStatus\": \"Active\",\n    \"addresses\": [],\n    \"displayName\": \"\",\n    \"emails\": [\n        {\n            \"value\": \"ea.cloud@forgerock.com\",\n            \"verified\": false\n        }\n    ],\n    \"id\": \"{{userId}}\",\n    \"ims\": [],\n    \"locale\": \"\",\n    \"name\": {\n        \"familyName\": \"user\",\n        \"givenName\": \"demo\"\n    },\n    \"nickName\": \"\",\n    \"phoneNumbers\": [],\n    \"preferences\": {},\n    \"preferredLanguage\": \"\",\n    \"profileUrl\": \"\",\n    \"timezone\": \"\",\n    \"title\": \"\",\n    \"userName\": \"demouser\",\n    \"userType\": \"\",\n    \"x509Certificates\": []\n}"
+								}
+							]
 						}
 					],
 					"description": "Manage and configure users in the tenant. Use the `/me` endpoint to manage the user who is logged into the current application.",
@@ -4222,10 +2970,6 @@
 										"type": "text"
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{tenantApiV1Url}}/password-policy",
 									"host": [
@@ -4235,7 +2979,7 @@
 										"password-policy"
 									]
 								},
-								"description": "Retreives the current password policy.\n\nFor a discussion of the output, see our documentation on [Password Policies](https://developer-cloud.forgerock.com/quickstarts/password-policies/)."
+								"description": "Retreives the current password policy.\n\nFor a discussion of the output, see our documentation on [Password Policies](https://developer-cloud.forgerock.com/api-reference/password-policies/)."
 							},
 							"response": [
 								{
@@ -4253,10 +2997,6 @@
 												"type": "text"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{tenantApiV1Url}}/password-policy?=",
 											"host": [
@@ -4348,7 +3088,7 @@
 										"password-policy"
 									]
 								},
-								"description": "Sets the password policy. Returns the configured password policy upon success.\n\nWhen configuring this REST call, include all options shown from the GET Password Policy call.\n\nFor details on each option, see our documentation on [Password Policies](https://developer-cloud.forgerock.com/quickstarts/password-policies/)."
+								"description": "Sets the password policy. Returns the configured password policy upon success.\n\nWhen configuring this REST call, include all options shown from the GET Password Policy call.\n\nFor details on each option, see our documentation on [Password Policies](https://developer-cloud.forgerock.com/api-reference/password-policies/)."
 							},
 							"response": [
 								{
@@ -4418,7 +3158,7 @@
 							]
 						}
 					],
-					"description": "Manage the global password policy for users of the tenant. Use the GET Password Policy call to review the current password policy, in JSON format. You can then use the output to format your desired password policy, through the Set Password Policy call.\n\n- The password age is set in `days`.\n- The password lock duration is set in `minutes`.\n- You can disable numeric options such as `maxPasswordAge` by setting them to 0.\n\nFor a more complete discussion, see our documentation on [Password Policies](https://developer-cloud.forgerock.com/quickstarts/password-policies/).",
+					"description": "Manage the global password policy for users of the tenant. Use the GET Password Policy call to review the current password policy, in JSON format. You can then use the output to format your desired password policy, through the Set Password Policy call.\n\n- The password age is set in `days`.\n- The password lock duration is set in `minutes`.\n- You can disable numeric options such as `maxPasswordAge` by setting them to 0.\n\nFor a more complete discussion, see our documentation on [Password Policies](https://developer-cloud.forgerock.com/api-reference/password-policies/).",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -4474,10 +3214,6 @@
 										"value": "application/json"
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{tenantApiV1Url}}/email-templates",
 									"host": [
@@ -4487,7 +3223,7 @@
 										"email-templates"
 									]
 								},
-								"description": "Gets a list of available email templates. You'll see output:\n\n* In JSON Format\n* Classified by template `type` and `id`\n\n\nFor more information, see our documentation on [Email Templates](https://developer-cloud.forgerock.com/quickstarts/email-templates/).\n\nTo send a test email via REST, review the output for the desired template `type` or `id`. Include that information in the POST Send Test Email REST call."
+								"description": "Gets a list of available email templates. You'll see output:\n\n* In JSON Format\n* Classified by template `type` and `id`\n\n\nFor more information, see our documentation on [Email Templates](https://developer-cloud.forgerock.com/api-reference/email-templates/).\n\nTo send a test email via REST, review the output for the desired template `type` or `id`. Include that information in the POST Send Test Email REST call."
 							},
 							"response": [
 								{
@@ -4506,10 +3242,6 @@
 												"value": "application/json"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{tenantApiV1Url}}/email-templates",
 											"host": [
@@ -4729,10 +3461,6 @@
 										"warning": "This is a duplicate header and will be overridden by the Authorization header generated by Postman."
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
 								"url": {
 									"raw": "{{tenantApiV1Url}}/hosted-pages",
 									"host": [
@@ -4761,10 +3489,6 @@
 												"value": "application/json"
 											}
 										],
-										"body": {
-											"mode": "raw",
-											"raw": ""
-										},
 										"url": {
 											"raw": "{{tenantApiV1Url}}/hosted-pages",
 											"host": [
@@ -4837,7 +3561,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"cssUrl\": \"https://ui-docs51.forgeblocks.com/css/hosted.css\",\n    \"forgotPasswordTitle\": \"Reset Your Password\",\n    \"logoUrl\": \"https://ui-docs51.forgeblocks.com/img/logo-forgerock.png\",\n    \"recoverUsernameTitle\": \"Recover Your Username\",\n    \"resetPasswordTitle\": \"Reset Password\",\n    \"signInTitle\": \"Sign In\",\n    \"signUpTitle\": \"Sign Up\"\n}"
+									"raw": "{\n    \"cssUrl\": \"https://ui-{{tenantName}}.forgeblocks.com/css/hosted.css\",\n    \"forgotPasswordTitle\": \"Reset Your Password\",\n    \"logoUrl\": \"https://ui-docs51.forgeblocks.com/img/logo-forgerock.png\",\n    \"recoverUsernameTitle\": \"Recover Your Username\",\n    \"resetPasswordTitle\": \"Reset Password\",\n    \"signInTitle\": \"Sign In\",\n    \"signUpTitle\": \"Sign Up\"\n}"
 								},
 								"url": {
 									"raw": "{{tenantApiV1Url}}/hosted-pages",
@@ -4958,6 +3682,2063 @@
 					"listen": "test",
 					"script": {
 						"id": "0cd4abd4-3da3-447f-bccb-649d0aae4408",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Authentication APIs",
+			"item": [
+				{
+					"name": "Password-based Authentication",
+					"item": [
+						{
+							"name": "Get Web App Token - Password Grant",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "f298b48d-fb9c-4c0a-a0c5-cc77ffd1a7dc",
+										"exec": [
+											"var jsonData = JSON.parse(responseBody);",
+											"postman.setEnvironmentVariable(\"userAccessToken\", jsonData.access_token);",
+											"postman.setEnvironmentVariable(\"refreshToken\", jsonData.refresh_token);",
+											"postman.setEnvironmentVariable(\"userIdToken\", jsonData.id_token);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "{{webAppClientSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "{{webAppClientId}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/x-www-form-urlencoded",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "urlencoded",
+									"urlencoded": [
+										{
+											"key": "grant_type",
+											"value": "password",
+											"description": "As allowed by your web app",
+											"type": "text"
+										},
+										{
+											"key": "username",
+											"value": "{{userName}}",
+											"type": "text"
+										},
+										{
+											"key": "password",
+											"value": "{{userPassword}}",
+											"type": "text"
+										},
+										{
+											"key": "scope",
+											"value": "{{scopes}}",
+											"description": "As defined for your app. *Note*: include a space (not a comma) between each scope.",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{oauth2Url}}/access_token",
+									"host": [
+										"{{oauth2Url}}"
+									],
+									"path": [
+										"access_token"
+									]
+								},
+								"description": "Requires credentials for an existing user, based on a web app. This call sets up a base64-encoded value for the web app via `Basic Auth` under authentication, using the Client ID and Client Secret for the web app.\n\n*Note*: This REST call requires manual configuration of the *Password* grant type for the subject web app. If you've set up a different user and password, adjust the REST call accordingly.\n\nReturns tokens specific to a user:\n* access_token\n* refresh_token\n* id_token\n\nPrerequisite: You can run this REST call after running the following calls:\n\n* Create a New Web App\n* Create User\n\nThe output from these calls automatically populates the variables needed here. You can also substitute the variables of your choice.\n\nIf you modify scopes, make sure they correspond to active scopes for your app."
+							},
+							"response": [
+								{
+									"name": "Get Web App Token - Password Grant",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/x-www-form-urlencoded"
+											},
+											{
+												"key": "Authorization",
+												"value": "Basic {{BASE_64_ENCODED_STRING}}",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "urlencoded",
+											"urlencoded": [
+												{
+													"key": "grant_type",
+													"value": "password",
+													"type": "text"
+												},
+												{
+													"key": "username",
+													"value": "{{userName}}",
+													"type": "text"
+												},
+												{
+													"key": "password",
+													"value": "{{userPassword}}",
+													"type": "text"
+												},
+												{
+													"key": "scope",
+													"value": "me.read me.update me.update-password password-policy.read user.reset-password user.recover-username user.create user.read openid profile",
+													"description": ". ",
+													"type": "text"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{oauth2Url}}/access_token",
+											"host": [
+												"{{oauth2Url}}"
+											],
+											"path": [
+												"access_token"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Frame-Options",
+											"value": "SAMEORIGIN"
+										},
+										{
+											"key": "Pragma",
+											"value": "no-cache"
+										},
+										{
+											"key": "Cache-Control",
+											"value": "no-store"
+										},
+										{
+											"key": "Date",
+											"value": "Thu, 07 Mar 2019 15:08:14 GMT"
+										},
+										{
+											"key": "Accept-Ranges",
+											"value": "bytes"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Transfer-Encoding",
+											"value": "chunked"
+										},
+										{
+											"key": "Via",
+											"value": "1.1 google"
+										},
+										{
+											"key": "Alt-Svc",
+											"value": "clear"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"access_token\": \"{{userAccessToken}}\",\n    \"refresh_token\": \"{{userRefreshToken}}\",\n    \"scope\": \"openid me.update profile user.recover-username user.read me.read user.create password-policy.read me.update-password user.reset-password\",\n    \"id_token\": \"{{userIdToken}}\",\n    \"token_type\": \"Bearer\",\n    \"expires_in\": 3599\n}"
+								}
+							]
+						},
+						{
+							"name": "UserInfo",
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{userAccessToken}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/x-www-form-urlencoded"
+									}
+								],
+								"url": {
+									"raw": "{{oauth2Url}}/userinfo",
+									"host": [
+										"{{oauth2Url}}"
+									],
+									"path": [
+										"userinfo"
+									]
+								},
+								"description": "Returns end user info. Requires an access_token created for the specific user, set as the *Bearer* token. You can acquire a user access_token from the Get Web App Token - Password Grant REST call."
+							},
+							"response": [
+								{
+									"name": "UserInfo",
+									"originalRequest": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Authorization",
+												"value": "Bearer {{userAccessToken}}"
+											},
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"value": "application/x-www-form-urlencoded",
+												"type": "text"
+											}
+										],
+										"url": {
+											"raw": "{{oauth2Url}}/userinfo",
+											"host": [
+												"{{oauth2Url}}"
+											],
+											"path": [
+												"userinfo"
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Frame-Options",
+											"value": "SAMEORIGIN"
+										},
+										{
+											"key": "Date",
+											"value": "Tue, 05 Mar 2019 15:51:43 GMT"
+										},
+										{
+											"key": "Accept-Ranges",
+											"value": "bytes"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json;charset=UTF-8"
+										},
+										{
+											"key": "Transfer-Encoding",
+											"value": "chunked"
+										},
+										{
+											"key": "Via",
+											"value": "1.1 google"
+										},
+										{
+											"key": "Alt-Svc",
+											"value": "clear"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"locale\": \"en-US\",\n    \"nickname\": \"Babs\",\n    \"profile_url\": \"https://login.example.com/bjensen\",\n    \"title\": \"Master Carpenter\",\n    \"zoneinfo\": \"America/Los_Angeles\",\n    \"sub\": \"bjensen@example.com\"\n}"
+								}
+							]
+						},
+						{
+							"name": "Check session",
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{oauth2Url}}/connect/checkSession?id_token={{userIdToken}}&prompt=none",
+									"host": [
+										"{{oauth2Url}}"
+									],
+									"path": [
+										"connect",
+										"checkSession"
+									],
+									"query": [
+										{
+											"key": "id_token",
+											"value": "{{userIdToken}}"
+										},
+										{
+											"key": "prompt",
+											"value": "none"
+										}
+									]
+								},
+								"description": "Check the session state of the user with the id_token. Allows clients to receive notifications. You can get the id_token from the Get Web App Token - Password Grant REST call.\n\nThis works with the `check_session_iframe` URL seen in the GET Discover REST call."
+							},
+							"response": [
+								{
+									"name": "Check session",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{oauth2Url}}/connect/checkSession?id_token={{userIdToken}}",
+											"host": [
+												"{{oauth2Url}}"
+											],
+											"path": [
+												"connect",
+												"checkSession"
+											],
+											"query": [
+												{
+													"key": "id_token",
+													"value": "{{userIdToken}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Accept-Ranges",
+											"value": "bytes",
+											"name": "Accept-Ranges",
+											"description": "Content-Types that are acceptable"
+										},
+										{
+											"key": "Alt-Svc",
+											"value": "clear",
+											"name": "Alt-Svc",
+											"description": "Custom header"
+										},
+										{
+											"key": "Content-Type",
+											"value": "text/html;charset=UTF-8",
+											"name": "Content-Type",
+											"description": "The mime type of this content"
+										},
+										{
+											"key": "Date",
+											"value": "Fri, 05 Oct 2018 15:04:06 GMT",
+											"name": "Date",
+											"description": "The date and time that the message was sent"
+										},
+										{
+											"key": "Transfer-Encoding",
+											"value": "chunked",
+											"name": "Transfer-Encoding",
+											"description": "The form of encoding used to safely transfer the entity to the user. Currently defined methods are: chunked, compress, deflate, gzip, identity."
+										},
+										{
+											"key": "Vary",
+											"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept",
+											"name": "Vary",
+											"description": "Tells downstream proxies how to match future request headers to decide whether the cached response can be used rather than requesting a fresh one from the origin server."
+										},
+										{
+											"key": "Via",
+											"value": "1.1 google",
+											"name": "Via",
+											"description": "Informs the client of proxies through which the response was sent."
+										},
+										{
+											"key": "X-Frame-Options",
+											"value": "SAMEORIGIN",
+											"name": "X-Frame-Options",
+											"description": "Clickjacking protection: \"deny\" - no rendering within a frame, \"sameorigin\" - no rendering if origin mismatch"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"at_hash\": \"UF3q_638GcngsEh6B5lglA\",\n    \"sub\": \"demouser\",\n    \"auditTrackingId\": \"a0deb639-832d-4c97-a4d2-4440c2727b02-7851\",\n    \"iss\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2\",\n    \"tokenName\": \"id_token\",\n    \"aud\": \"18c0d0bf98973a2660364198d45f927d\",\n    \"c_hash\": \"gQkCnvaICC0kT4A1wXyukA\",\n    \"acr\": \"0\",\n    \"org.forgerock.openidconnect.ops\": \"MYRjCWkJ0G4gBWDPEIfiVjtrLp4\",\n    \"azp\": \"18c0d0bf98973a2660364198d45f927d\",\n    \"auth_time\": 1551712897,\n    \"realm\": \"/\",\n    \"exp\": 1551716498,\n    \"tokenType\": \"JWTToken\",\n    \"iat\": 1551712898,\n    \"forgerock\": {\n        \"sig\": \"2+fDlj)0>F2y?aL9m5h:S@&]!T[=)KE#LA}.ik.c\"\n    }\n}"
+								}
+							]
+						},
+						{
+							"name": "End session",
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{oauth2Url}}/connect/endSession?id_token_hint={{userIdToken}}&post_logout_redirect_uri={{logoutUrl}}",
+									"host": [
+										"{{oauth2Url}}"
+									],
+									"path": [
+										"connect",
+										"endSession"
+									],
+									"query": [
+										{
+											"key": "id_token_hint",
+											"value": "{{userIdToken}}"
+										},
+										{
+											"key": "post_logout_redirect_uri",
+											"value": "{{logoutUrl}}"
+										}
+									]
+								},
+								"description": "End the current session. Requires the id_token created for the user, which is set to id_token_hint. You can get this value from the POST GET Web App Token - Password Grant REST call."
+							},
+							"response": []
+						}
+					],
+					"description": "The REST calls in this section work *only* for Web Apps configured with the `password` grant type.",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "f0e7b75b-2b39-4b7f-8d49-7d5fd8aaa582",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "7e3c180a-83bd-44ff-bdc2-a0b7588af66f",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "PKCE-based Authentication",
+					"item": [
+						{
+							"name": "PKCE Auth Step 1: Get session",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "82337149-a08b-4c1c-9840-bc1e97c4377c",
+										"exec": [
+											"var json = JSON.parse(responseBody);",
+											"pm.environment.set('ssoToken', json.tokenId);",
+											"console.log(`Acquired session ${json.tokenId}`);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-OpenAM-Username",
+										"value": "bjensen@example.com"
+									},
+									{
+										"key": "X-OpenAM-Password",
+										"value": "Passwordy1#"
+									},
+									{
+										"key": "Accept-API-Version",
+										"value": "resource=2.0,protocol=1.0"
+									},
+									{
+										"key": "Host",
+										"value": "openam",
+										"disabled": true
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{authRealmsUrl}}json/realms/root/authenticate",
+									"host": [
+										"{{authRealmsUrl}}json"
+									],
+									"path": [
+										"realms",
+										"root",
+										"authenticate"
+									]
+								},
+								"description": "Gets the SSO Token for the user, also known as the `iPlanetDirectoryPro` token."
+							},
+							"response": []
+						},
+						{
+							"name": "Native/SPA PKCE Auth Step 2: Get auth code",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "2e66db2f-2168-4660-9874-aca5853178d7",
+										"exec": [
+											"var url = require('url');",
+											"",
+											"var location = pm.response.headers.find(x => x.key.toLowerCase() === 'location');",
+											"if (!location) {",
+											"    console.log('Failed to get redirect location');",
+											"    return;",
+											"}",
+											"",
+											"var parsedUrl = url.parse(location.value, true);",
+											"if (!parsedUrl.query.code) {",
+											"    console.log('Failed to get authorization code');",
+											"    return;",
+											"}",
+											"",
+											"pm.environment.set('authorizationCode', parsedUrl.query.code);",
+											"console.log(`Captured auth code ${parsedUrl.query.code}`);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Cookie",
+										"type": "text",
+										"value": "iPlanetDirectoryPro={{ssoToken}}",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{authRealmsUrl}}oauth2/realms/root/authorize?grant_type=authorization_code&client_id={{spaAppClientId}}&response_type=code&scope=openid&redirect_uri=https://example.com/homeLogin/&code_challenge=j3wKnK2Fa_mc2tgdqa6GtUfCYjdWSA5S23JKTTtPF8Y&code_challenge_method=S256&state=abc123",
+									"host": [
+										"{{authRealmsUrl}}oauth2"
+									],
+									"path": [
+										"realms",
+										"root",
+										"authorize"
+									],
+									"query": [
+										{
+											"key": "grant_type",
+											"value": "authorization_code"
+										},
+										{
+											"key": "client_id",
+											"value": "{{spaAppClientId}}"
+										},
+										{
+											"key": "response_type",
+											"value": "code"
+										},
+										{
+											"key": "scope",
+											"value": "openid"
+										},
+										{
+											"key": "redirect_uri",
+											"value": "https://example.com/homeLogin/"
+										},
+										{
+											"key": "code_challenge",
+											"value": "j3wKnK2Fa_mc2tgdqa6GtUfCYjdWSA5S23JKTTtPF8Y"
+										},
+										{
+											"key": "code_challenge_method",
+											"value": "S256"
+										},
+										{
+											"key": "state",
+											"value": "abc123"
+										}
+									]
+								},
+								"description": "Uses the SSO token and SPA Client ID, and produces an authorization code.\n\n*Note*: A 302 message is expected; this REST call includes a script which pulls the authorization code from the verbose output, for step 3."
+							},
+							"response": []
+						},
+						{
+							"name": "Native/SPA PKCE Auth Step 3: Get access token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "03ed5da3-1376-4c70-8e80-4e148b029890",
+										"exec": [
+											"var jsonData = JSON.parse(responseBody);",
+											"postman.setEnvironmentVariable(\"userAccessToken\", jsonData.access_token);",
+											"postman.setEnvironmentVariable(\"refreshToken\", jsonData.refresh_token);",
+											"postman.setEnvironmentVariable(\"userIdToken\", jsonData.id_token);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/x-www-form-urlencoded"
+									}
+								],
+								"body": {
+									"mode": "urlencoded",
+									"urlencoded": [
+										{
+											"key": "grant_type",
+											"value": "authorization_code",
+											"type": "text"
+										},
+										{
+											"key": "code",
+											"value": "{{authorizationCode}}",
+											"type": "text"
+										},
+										{
+											"key": "client_id",
+											"value": "{{spaAppClientId}}",
+											"type": "text"
+										},
+										{
+											"key": "redirect_uri",
+											"value": "https://example.com/homeLogin/",
+											"type": "text"
+										},
+										{
+											"key": "code_verifier",
+											"value": "ZpJiIM_G0SE9WlxzS69Cq0mQh8uyFaeEbILlW8tHs62SmEE6n7Nke0XJGx_F4OduTI4",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{authRealmsUrl}}oauth2/realms/root/access_token",
+									"host": [
+										"{{authRealmsUrl}}oauth2"
+									],
+									"path": [
+										"realms",
+										"root",
+										"access_token"
+									]
+								},
+								"description": "Takes the authorization code from step 2, along with the Native/SPA app client ID, to get the access token using Proof Key for Code Exchange (PKCE). \n\nTo enhance security, the REST call uses a unique authorization code instead of the app client secret."
+							},
+							"response": []
+						},
+						{
+							"name": "Web App PKCE Auth Step 2: Get auth code",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "2e66db2f-2168-4660-9874-aca5853178d7",
+										"exec": [
+											"var url = require('url');",
+											"",
+											"var location = pm.response.headers.find(x => x.key.toLowerCase() === 'location');",
+											"if (!location) {",
+											"    console.log('Failed to get redirect location');",
+											"    return;",
+											"}",
+											"",
+											"var parsedUrl = url.parse(location.value, true);",
+											"if (!parsedUrl.query.code) {",
+											"    console.log('Failed to get authorization code');",
+											"    return;",
+											"}",
+											"",
+											"pm.environment.set('authorizationCode', parsedUrl.query.code);",
+											"console.log(`Captured auth code ${parsedUrl.query.code}`);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [
+									{
+										"key": "Cookie",
+										"type": "text",
+										"value": "iPlanetDirectoryPro={{ssoToken}}",
+										"disabled": true
+									}
+								],
+								"url": {
+									"raw": "{{authRealmsUrl}}oauth2/realms/root/authorize?grant_type=authorization_code&client_id={{webAppClientId}}&response_type=code&scope=openid&redirect_uri=https://example.com/homeLogin/&code_challenge=j3wKnK2Fa_mc2tgdqa6GtUfCYjdWSA5S23JKTTtPF8Y&code_challenge_method=S256&state=abc123",
+									"host": [
+										"{{authRealmsUrl}}oauth2"
+									],
+									"path": [
+										"realms",
+										"root",
+										"authorize"
+									],
+									"query": [
+										{
+											"key": "grant_type",
+											"value": "authorization_code"
+										},
+										{
+											"key": "client_id",
+											"value": "{{webAppClientId}}"
+										},
+										{
+											"key": "response_type",
+											"value": "code"
+										},
+										{
+											"key": "scope",
+											"value": "openid"
+										},
+										{
+											"key": "redirect_uri",
+											"value": "https://example.com/homeLogin/"
+										},
+										{
+											"key": "code_challenge",
+											"value": "j3wKnK2Fa_mc2tgdqa6GtUfCYjdWSA5S23JKTTtPF8Y"
+										},
+										{
+											"key": "code_challenge_method",
+											"value": "S256"
+										},
+										{
+											"key": "state",
+											"value": "abc123"
+										}
+									]
+								},
+								"description": "Uses the SSO token and web app credentials to produce an authorization code.\n\n*Note*: A 302 message is expected; this REST call includes a script which pulls the authorization code from the verbose output for step 3."
+							},
+							"response": []
+						},
+						{
+							"name": "Web App PKCE Auth Step 3: Get access token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "57286108-84c5-4399-87e7-4cf9c05688a4",
+										"exec": [
+											"var jsonData = JSON.parse(responseBody);",
+											"postman.setEnvironmentVariable(\"userAccessToken\", jsonData.access_token);",
+											"postman.setEnvironmentVariable(\"refreshToken\", jsonData.refresh_token);",
+											"postman.setEnvironmentVariable(\"userIdToken\", jsonData.id_token);"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "{{webAppClientSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "{{webAppClientId}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"type": "text",
+										"value": "application/x-www-form-urlencoded"
+									}
+								],
+								"body": {
+									"mode": "urlencoded",
+									"urlencoded": [
+										{
+											"key": "grant_type",
+											"value": "authorization_code",
+											"type": "text"
+										},
+										{
+											"key": "code",
+											"value": "{{authorizationCode}}",
+											"type": "text"
+										},
+										{
+											"key": "client_id",
+											"value": "{{webAppClientId}}",
+											"type": "text"
+										},
+										{
+											"key": "redirect_uri",
+											"value": "https://example.com/homeLogin/",
+											"type": "text"
+										},
+										{
+											"key": "code_verifier",
+											"value": "ZpJiIM_G0SE9WlxzS69Cq0mQh8uyFaeEbILlW8tHs62SmEE6n7Nke0XJGx_F4OduTI4",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{authRealmsUrl}}oauth2/realms/root/access_token",
+									"host": [
+										"{{authRealmsUrl}}oauth2"
+									],
+									"path": [
+										"realms",
+										"root",
+										"access_token"
+									]
+								},
+								"description": "Takes the authorization code from step 2, along with the Web app client ID, to get the access token using Proof Key for Code Exchange (PKCE). \n\nTo enhance security, the REST call uses a unique authorization code.\n\nEven though the REST call includes the base64 encoding of the client ID and client secret, PKCE enhances security for web apps, as it prevents a malicious user from using:\n\n* An intercepted authorization code\n* Data from a request to the /authorize endpoint (as shown in step 2)"
+							},
+							"response": []
+						}
+					],
+					"description": "This section helps secure access tokens without client secrets. \n\nFor Native/SPA apps, this is critical; otherwise, client secrets would be stored on end-user devices and browsers. \n\nFor Web apps, it reduces risks, as malicious users can't use an intercepted authentication code.\n\nSecurity is ensured by a `code_verifier` and `code_challenge`. A `code_verifier` is a cryptographically random string. The `code_challenge` depends on the value of `code_challenge_method`. \n\n* If `code_challenge_method` = `plain`, `code_challenge` = `code_verifier`.\n* If `code_challenge_method` = `S256`, `code_challenge` = `BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))`.\n\nFor the purpose of this REST collection, we've set up an arbitrary value for the `code_verifier`, with a corresponding value for `code_challenge`.",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "a8430055-c7b2-4532-94dd-222c6f819613",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "8d13e0df-9833-4645-a9f8-3fc97dde5069",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Token Analysis",
+					"item": [
+						{
+							"name": "Tokeninfo",
+							"request": {
+								"auth": {
+									"type": "noauth"
+								},
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{oauth2Url}}/tokeninfo?access_token={{userAccessToken}}",
+									"host": [
+										"{{oauth2Url}}"
+									],
+									"path": [
+										"tokeninfo"
+									],
+									"query": [
+										{
+											"key": "access_token",
+											"value": "{{userAccessToken}}"
+										}
+									]
+								},
+								"description": "Validates a user ID token for debugging. Requires an access_token created for the specific user, set as the *Bearer* token. You can acquire a user access_token from the Get Web App Token - Password Grant REST call."
+							},
+							"response": [
+								{
+									"name": "Tokeninfo",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{oauth2Url}}/tokeninfo?access_token={{userAccessToken}}",
+											"host": [
+												"{{oauth2Url}}"
+											],
+											"path": [
+												"tokeninfo"
+											],
+											"query": [
+												{
+													"key": "access_token",
+													"value": "{{userAccessToken}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Frame-Options",
+											"value": "SAMEORIGIN"
+										},
+										{
+											"key": "Cache-Control",
+											"value": "no-cache, no-store"
+										},
+										{
+											"key": "Date",
+											"value": "Thu, 07 Mar 2019 15:11:33 GMT"
+										},
+										{
+											"key": "Accept-Ranges",
+											"value": "bytes"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Transfer-Encoding",
+											"value": "chunked"
+										},
+										{
+											"key": "Via",
+											"value": "1.1 google"
+										},
+										{
+											"key": "Alt-Svc",
+											"value": "clear"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"sub\": \"bjensen@example.com\",\n    \"auth_level\": 0,\n    \"auditTrackingId\": \"3d9f9676-faca-442c-b007-f6a2ea8b67fd-3646\",\n    \"me.update\": \"\",\n    \"iss\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2\",\n    \"tokenName\": \"access_token\",\n    \"token_type\": \"Bearer\",\n    \"user.recover-username\": \"\",\n    \"user.read\": \"\",\n    \"password-policy.read\": \"\",\n    \"grant_type\": \"password\",\n    \"scope\": [\n        \"openid\",\n        \"me.update\",\n        \"profile\",\n        \"user.recover-username\",\n        \"user.read\",\n        \"me.read\",\n        \"user.create\",\n        \"password-policy.read\",\n        \"me.update-password\",\n        \"user.reset-password\"\n    ],\n    \"auth_time\": 1551971292,\n    \"me.update-password\": \"\",\n    \"exp\": 1551974893,\n    \"iat\": 1551971293,\n    \"expires_in\": 3600,\n    \"jti\": \"PWL_Al8ylGiL_L5liNSxJaDIb_4\",\n    \"cts\": \"OAUTH2_STATELESS_GRANT\",\n    \"openid\": \"\",\n    \"profile\": \"\",\n    \"authGrantId\": \"cfQfXBMdSs91iktKG6Uo21i7-7Y\",\n    \"access_token\": \"{{userAccessToken}}\",\n    \"aud\": \"750e67f55c7693f17cae0f8cdae4b9c8\",\n    \"me.read\": \"\",\n    \"user.create\": \"\",\n    \"nbf\": 1551971293,\n    \"realm\": \"/\",\n    \"user.reset-password\": \"\"\n}"
+								}
+							]
+						},
+						{
+							"name": "Introspect",
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "{{webAppClientSecret}}",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "{{webAppClientId}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{oauth2Url}}/introspect?token={{userAccessToken}}",
+									"host": [
+										"{{oauth2Url}}"
+									],
+									"path": [
+										"introspect"
+									],
+									"query": [
+										{
+											"key": "token",
+											"value": "{{userAccessToken}}"
+										}
+									]
+								},
+								"description": "Returns the content of an access token, including scopes. Requires the Client ID and Client Secret for an existing web app."
+							},
+							"response": [
+								{
+									"name": "Introspect",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/x-www-form-urlencoded"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{oauth2Url}}/introspect?token={{userAccessToken}}",
+											"host": [
+												"{{oauth2Url}}"
+											],
+											"path": [
+												"introspect"
+											],
+											"query": [
+												{
+													"key": "token",
+													"value": "{{userAccessToken}}"
+												}
+											]
+										}
+									},
+									"status": "Unauthorized",
+									"code": 401,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Frame-Options",
+											"value": "SAMEORIGIN"
+										},
+										{
+											"key": "Date",
+											"value": "Fri, 14 Jun 2019 15:55:22 GMT"
+										},
+										{
+											"key": "Accept-Ranges",
+											"value": "bytes"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										},
+										{
+											"key": "Transfer-Encoding",
+											"value": "chunked"
+										},
+										{
+											"key": "Via",
+											"value": "1.1 google"
+										},
+										{
+											"key": "Alt-Svc",
+											"value": "clear"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"error_description\": \"Client authentication failed\",\n    \"error\": \"invalid_client\"\n}"
+								},
+								{
+									"name": "Introspect",
+									"originalRequest": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/x-www-form-urlencoded"
+											},
+											{
+												"description": "Base 64 Encoded version of Basic {{clientId}}:{{clientSecret}}",
+												"key": "Authorization",
+												"value": "Basic {{BASE_64_ENCODED_STRING}}",
+												"warning": "This is a duplicate header and will be overridden by the Authorization header generated by Postman.",
+												"disabled": true
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{oauth2Url}}/introspect?token={{userAccessToken}}",
+											"host": [
+												"{{oauth2Url}}"
+											],
+											"path": [
+												"introspect"
+											],
+											"query": [
+												{
+													"key": "token",
+													"value": "{{userAccessToken}}"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "X-Frame-Options",
+											"value": "SAMEORIGIN"
+										},
+										{
+											"key": "Date",
+											"value": "Thu, 07 Mar 2019 15:16:13 GMT"
+										},
+										{
+											"key": "Accept-Ranges",
+											"value": "bytes"
+										},
+										{
+											"key": "Vary",
+											"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
+										},
+										{
+											"key": "Content-Type",
+											"value": "application/json;charset=UTF-8"
+										},
+										{
+											"key": "Transfer-Encoding",
+											"value": "chunked"
+										},
+										{
+											"key": "Via",
+											"value": "1.1 google"
+										},
+										{
+											"key": "Alt-Svc",
+											"value": "clear"
+										}
+									],
+									"cookie": [],
+									"body": "{\n    \"active\": true,\n    \"scope\": \"user.read me.read user.create password-policy.read openid me.update profile me.update-password user.recover-username user.reset-password\",\n    \"client_id\": \"750e67f55c7693f17cae0f8cdae4b9c8\",\n    \"user_id\": \"bjensen@example.com\",\n    \"token_type\": \"Bearer\",\n    \"exp\": 1551974893,\n    \"sub\": \"bjensen@example.com\",\n    \"iss\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2\",\n    \"auth_level\": 0\n}"
+								}
+							]
+						}
+					],
+					"description": "The following calls help examine the contents of different JWT tokens.",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "61d36b4d-360f-4471-901c-1cdeeae082e8",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "7a196286-2c52-4131-865b-a488590fccc6",
+								"type": "text/javascript",
+								"exec": [
+									""
+								]
+							}
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Get Refresh Token",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "87002a5c-5df5-42a2-ac89-6a717f7a3c16",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setEnvironmentVariable(\"userAccessToken\", jsonData.access_token);",
+									"postman.setEnvironmentVariable(\"refreshToken\", jsonData.refresh_token);",
+									"postman.setEnvironmentVariable(\"userIdToken\", jsonData.id_token);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "{{webAppClientSecret}}",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "{{webAppClientId}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "grant_type",
+									"value": "refresh_token",
+									"type": "text"
+								},
+								{
+									"key": "refresh_token",
+									"value": "{{refreshToken}}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{oauth2Url}}/access_token",
+							"host": [
+								"{{oauth2Url}}"
+							],
+							"path": [
+								"access_token"
+							]
+						},
+						"description": "A refresh_token can be used to obtain a new access_token. The new access_token may include the same or a more narrow set of scopes."
+					},
+					"response": [
+						{
+							"name": "Get Refresh Token",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded"
+									},
+									{
+										"description": "Base64-Encoded version of Basic{{webAppClientId}}:{{webAppSecret}})",
+										"key": "Authorization",
+										"type": "text",
+										"value": "Basic {{BASE_64_ENCODED_STRING}}"
+									}
+								],
+								"body": {
+									"mode": "urlencoded",
+									"urlencoded": [
+										{
+											"key": "grant_type",
+											"value": "refresh_token",
+											"type": "text"
+										},
+										{
+											"key": "refresh_token",
+											"value": "{{refreshToken}}",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{oauth2Url}}/access_token",
+									"host": [
+										"{{oauth2Url}}"
+									],
+									"path": [
+										"access_token"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "X-Frame-Options",
+									"value": "SAMEORIGIN"
+								},
+								{
+									"key": "Pragma",
+									"value": "no-cache"
+								},
+								{
+									"key": "Cache-Control",
+									"value": "no-store"
+								},
+								{
+									"key": "Date",
+									"value": "Wed, 06 Mar 2019 17:14:40 GMT"
+								},
+								{
+									"key": "Accept-Ranges",
+									"value": "bytes"
+								},
+								{
+									"key": "Vary",
+									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								},
+								{
+									"key": "Via",
+									"value": "1.1 google"
+								},
+								{
+									"key": "Alt-Svc",
+									"value": "clear"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"access_token\": \"{{accessToken}}\",\n    \"refresh_token\": \"{{refreshToken}}\",\n    \"scope\": \"user.read me.read password-policy.read openid profile user.recover-username user.reset-password\",\n    \"id_token\": \"{{idToken}}\",\n    \"token_type\": \"Bearer\",\n    \"expires_in\": 3599\n}"
+						}
+					]
+				},
+				{
+					"name": "Get Web App Token - Auth Code Grant (Without Browser)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "87002a5c-5df5-42a2-ac89-6a717f7a3c16",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setEnvironmentVariable(\"userAccessToken\", jsonData.access_token);",
+									"postman.setEnvironmentVariable(\"refreshToken\", jsonData.refresh_token);",
+									"postman.setEnvironmentVariable(\"userIdToken\", jsonData.id_token);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "{{webAppClientSecret}}",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "{{webAppClientId}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "grant_type",
+									"value": "client_credentials",
+									"type": "text"
+								},
+								{
+									"key": "code",
+									"value": "{{authorizationCode}}",
+									"description": "Use the code returned from REST calls on the /oauth2/authorize endpoint.",
+									"type": "text"
+								},
+								{
+									"key": "redirect_uri",
+									"value": "{{loginUrl}}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{oauth2Url}}/access_token",
+							"host": [
+								"{{oauth2Url}}"
+							],
+							"path": [
+								"access_token"
+							]
+						},
+						"description": "Used when a client such as a Java application running on a server requires access to protected resources."
+					},
+					"response": [
+						{
+							"name": "Get Web App Token - Auth Code Grant (Without Browser)",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded"
+									}
+								],
+								"body": {
+									"mode": "urlencoded",
+									"urlencoded": [
+										{
+											"key": "grant_type",
+											"value": "client_credentials",
+											"type": "text"
+										},
+										{
+											"key": "code",
+											"value": "{{authCode}}",
+											"description": "Use the code returned from REST calls on the /oauth2/authorize endpoint.",
+											"type": "text"
+										},
+										{
+											"key": "redirect_uri",
+											"value": "http://localhost:9080/callback/non-hosted",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{oauth2Url}}/access_token",
+									"host": [
+										"{{oauth2Url}}"
+									],
+									"path": [
+										"access_token"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "X-Frame-Options",
+									"value": "SAMEORIGIN"
+								},
+								{
+									"key": "Pragma",
+									"value": "no-cache"
+								},
+								{
+									"key": "Cache-Control",
+									"value": "no-store"
+								},
+								{
+									"key": "Date",
+									"value": "Fri, 08 Mar 2019 17:24:09 GMT"
+								},
+								{
+									"key": "Accept-Ranges",
+									"value": "bytes"
+								},
+								{
+									"key": "Vary",
+									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								},
+								{
+									"key": "Via",
+									"value": "1.1 google"
+								},
+								{
+									"key": "Alt-Svc",
+									"value": "clear"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"access_token\": \"{{accessToken}}\",\n    \"scope\": \"openid\",\n    \"id_token\": \"{{idToken}}\",\n    \"token_type\": \"Bearer\",\n    \"expires_in\": 3598\n}"
+						}
+					]
+				},
+				{
+					"name": "Get Web App Token - Auth Code Grant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "87002a5c-5df5-42a2-ac89-6a717f7a3c16",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setEnvironmentVariable(\"userAccessToken\", jsonData.access_token);",
+									"postman.setEnvironmentVariable(\"refreshToken\", jsonData.refresh_token);",
+									"postman.setEnvironmentVariable(\"userIdToken\", jsonData.id_token);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "{{webAppClientSecret}}",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "{{webAppClientId}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "grant_type",
+									"value": "client_credentials",
+									"type": "text"
+								},
+								{
+									"key": "code",
+									"value": "{{authorizationCode}}",
+									"description": "Use the authorization code returned from REST calls on the /authorize endpoint.",
+									"type": "text"
+								},
+								{
+									"key": "redirect_uri",
+									"value": "{{loginUrl}}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{oauth2Url}}/access_token",
+							"host": [
+								"{{oauth2Url}}"
+							],
+							"path": [
+								"access_token"
+							]
+						},
+						"description": "Used when a client such as a Java application running on a server requires access to protected resources."
+					},
+					"response": [
+						{
+							"name": "Get Web App Token - Auth Code Grant (error)",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded"
+									}
+								],
+								"body": {
+									"mode": "urlencoded",
+									"urlencoded": [
+										{
+											"key": "grant_type",
+											"value": "client_credentials",
+											"type": "text"
+										},
+										{
+											"key": "code",
+											"value": "{{authCode}}",
+											"description": "Use the authorization code returned from REST calls on the /authorize endpoint.",
+											"type": "text"
+										},
+										{
+											"key": "redirect_uri",
+											"value": "http://localhost:9080/callback",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{oauth2Url}}/access_token",
+									"host": [
+										"{{oauth2Url}}"
+									],
+									"path": [
+										"access_token"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "X-Frame-Options",
+									"value": "SAMEORIGIN"
+								},
+								{
+									"key": "Pragma",
+									"value": "no-cache"
+								},
+								{
+									"key": "Cache-Control",
+									"value": "no-store"
+								},
+								{
+									"key": "Date",
+									"value": "Fri, 08 Mar 2019 17:28:54 GMT"
+								},
+								{
+									"key": "Accept-Ranges",
+									"value": "bytes"
+								},
+								{
+									"key": "Vary",
+									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								},
+								{
+									"key": "Via",
+									"value": "1.1 google"
+								},
+								{
+									"key": "Alt-Svc",
+									"value": "clear"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"access_token\": \"{{accessToken}}\",\n    \"scope\": \"openid\",\n    \"id_token\": \"{{idToken}}\",\n    \"token_type\": \"Bearer\",\n    \"expires_in\": 3599\n}"
+						}
+					]
+				},
+				{
+					"name": "Get M2M (Service) token - Client Credentials Grant",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "ac7f9a4c-3d98-4004-a573-ff5ae1f2eeb1",
+								"exec": [
+									"var jsonData = JSON.parse(responseBody);",
+									"postman.setEnvironmentVariable(\"appAccessToken\", jsonData.access_token);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "{{m2mAppClientSecret}}",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "{{m2mAppClientId}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "scope",
+									"value": "app.read email-template.read password-policy.read",
+									"type": "text"
+								},
+								{
+									"key": "grant_type",
+									"value": "client_credentials",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{oauth2Url}}/access_token",
+							"host": [
+								"{{oauth2Url}}"
+							],
+							"path": [
+								"access_token"
+							]
+						},
+						"description": "Requires a Client ID and Client Secret for the service app. This call sets up a base64-encoded value for the service app via `Basic Auth` under authentication, using these values.\n\nReturns the following tokens specific to the service app:\n* access_token\n\nYou'll need this token for other REST calls for the service app."
+					},
+					"response": [
+						{
+							"name": "Get M2M (Service) token - Client Credentials Grant",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded"
+									}
+								],
+								"body": {
+									"mode": "urlencoded",
+									"urlencoded": [
+										{
+											"key": "scope",
+											"value": "app.read email-template.read password-policy.read user.reset-password user.recover-username user.create user.read user.update",
+											"type": "text"
+										},
+										{
+											"key": "grant_type",
+											"value": "client_credentials",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{oauth2Url}}/access_token",
+									"host": [
+										"{{oauth2Url}}"
+									],
+									"path": [
+										"access_token"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "X-Frame-Options",
+									"value": "SAMEORIGIN"
+								},
+								{
+									"key": "Pragma",
+									"value": "no-cache"
+								},
+								{
+									"key": "Cache-Control",
+									"value": "no-store"
+								},
+								{
+									"key": "Date",
+									"value": "Thu, 07 Mar 2019 15:14:55 GMT"
+								},
+								{
+									"key": "Accept-Ranges",
+									"value": "bytes"
+								},
+								{
+									"key": "Vary",
+									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								},
+								{
+									"key": "Via",
+									"value": "1.1 google"
+								},
+								{
+									"key": "Alt-Svc",
+									"value": "clear"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"access_token\": \"{{serviceAccessToken}}\",\n    \"scope\": \"user.update app.read user.recover-username user.read user.create password-policy.read email-template.read user.reset-password\",\n    \"token_type\": \"Bearer\",\n    \"expires_in\": 3599\n}"
+						}
+					]
+				},
+				{
+					"name": "Revoke",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "token",
+									"value": "{{userAccessToken}}",
+									"type": "text"
+								},
+								{
+									"key": "client_id",
+									"value": "{{webAppClientId}}",
+									"type": "text"
+								},
+								{
+									"key": "client_secret",
+									"value": "{{webAppClientSecret}}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{oauth2Url}}/token/revoke",
+							"host": [
+								"{{oauth2Url}}"
+							],
+							"path": [
+								"token",
+								"revoke"
+							]
+						},
+						"description": "Revoke an access_token for an app. Requires an access_token created for the app, set as the *Bearer* token. You can acquire an app access_token from the Get Web App Token - Auth Code Grant REST call."
+					},
+					"response": [
+						{
+							"name": "Revoke",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded"
+									}
+								],
+								"body": {
+									"mode": "urlencoded",
+									"urlencoded": [
+										{
+											"key": "token",
+											"value": "{{accessToken}}",
+											"type": "text"
+										},
+										{
+											"key": "client_id",
+											"value": "{{clientId}}",
+											"type": "text"
+										},
+										{
+											"key": "client_secret",
+											"value": "{{clientSecret}}",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{oauth2Url}}/token/revoke",
+									"host": [
+										"{{oauth2Url}}"
+									],
+									"path": [
+										"token",
+										"revoke"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "Text",
+							"header": [],
+							"cookie": [],
+							"body": "{}"
+						}
+					]
+				},
+				{
+					"name": "Discover",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{oauth2Url}}/.well-known/openid-configuration",
+							"host": [
+								"{{oauth2Url}}"
+							],
+							"path": [
+								".well-known",
+								"openid-configuration"
+							]
+						},
+						"description": "Retrieves configuration data, including:\n\n* Endpoints.\n* Default scopes. For a full list, see our documentation on <a href=\"https://developer-cloud.forgerock.com/reference/scopes/\" target=\"_blank\">Scopes</a>.\n* Encryption and digital signature algorithms. \n* Supported claims, such as `address` and `phone_number`."
+					},
+					"response": [
+						{
+							"name": "Discover",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{oauth2Url}}/.well-known/openid-configuration",
+									"host": [
+										"{{oauth2Url}}"
+									],
+									"path": [
+										".well-known",
+										"openid-configuration"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "X-Frame-Options",
+									"value": "SAMEORIGIN"
+								},
+								{
+									"key": "Date",
+									"value": "Thu, 07 Mar 2019 18:47:26 GMT"
+								},
+								{
+									"key": "Accept-Ranges",
+									"value": "bytes"
+								},
+								{
+									"key": "Vary",
+									"value": "Accept-Charset, Accept-Encoding, Accept-Language, Accept"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json;charset=UTF-8"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked"
+								},
+								{
+									"key": "Via",
+									"value": "1.1 google"
+								},
+								{
+									"key": "Alt-Svc",
+									"value": "clear"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"request_parameter_supported\": true,\n    \"claims_parameter_supported\": false,\n    \"introspection_endpoint\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/introspect\",\n    \"check_session_iframe\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/connect/checkSession\",\n    \"scopes_supported\": [\n        \"address\",\n        \"phone\",\n        \"openid\",\n        \"profile\",\n        \"email\"\n    ],\n    \"issuer\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2\",\n    \"id_token_encryption_enc_values_supported\": [\n        \"A256GCM\",\n        \"A192GCM\",\n        \"A128GCM\",\n        \"A128CBC-HS256\",\n        \"A192CBC-HS384\",\n        \"A256CBC-HS512\"\n    ],\n    \"acr_values_supported\": [],\n    \"userinfo_encryption_enc_values_supported\": [\n        \"A256GCM\",\n        \"A192GCM\",\n        \"A128GCM\",\n        \"A128CBC-HS256\",\n        \"A192CBC-HS384\",\n        \"A256CBC-HS512\"\n    ],\n    \"authorization_endpoint\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/authorize\",\n    \"request_object_encryption_enc_values_supported\": [\n        \"A256GCM\",\n        \"A192GCM\",\n        \"A128GCM\",\n        \"A128CBC-HS256\",\n        \"A192CBC-HS384\",\n        \"A256CBC-HS512\"\n    ],\n    \"rcs_request_encryption_alg_values_supported\": [\n        \"RSA-OAEP\",\n        \"RSA-OAEP-256\",\n        \"A128KW\",\n        \"RSA1_5\",\n        \"A256KW\",\n        \"dir\",\n        \"A192KW\"\n    ],\n    \"claims_supported\": [\n        \"zoneinfo\",\n        \"address\",\n        \"profile\",\n        \"name\",\n        \"phone_number\",\n        \"given_name\",\n        \"locale\",\n        \"family_name\",\n        \"email\"\n    ],\n    \"userinfo_signing_alg_values_supported\": [\n        \"ES384\",\n        \"HS256\",\n        \"HS512\",\n        \"ES256\",\n        \"RS256\",\n        \"HS384\",\n        \"ES512\"\n    ],\n    \"rcs_request_signing_alg_values_supported\": [\n        \"PS384\",\n        \"ES384\",\n        \"RS384\",\n        \"HS256\",\n        \"HS512\",\n        \"ES256\",\n        \"RS256\",\n        \"HS384\",\n        \"ES512\",\n        \"PS256\",\n        \"PS512\",\n        \"RS512\"\n    ],\n    \"token_endpoint_auth_methods_supported\": [\n        \"client_secret_post\",\n        \"private_key_jwt\",\n        \"client_secret_basic\"\n    ],\n    \"token_endpoint\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/access_token\",\n    \"response_types_supported\": [\n        \"code token id_token\",\n        \"code\",\n        \"code id_token\",\n        \"device_code\",\n        \"id_token\",\n        \"code token\",\n        \"token\",\n        \"token id_token\"\n    ],\n    \"request_uri_parameter_supported\": true,\n    \"rcs_response_encryption_enc_values_supported\": [\n        \"A256GCM\",\n        \"A192GCM\",\n        \"A128GCM\",\n        \"A128CBC-HS256\",\n        \"A192CBC-HS384\",\n        \"A256CBC-HS512\"\n    ],\n    \"userinfo_encryption_alg_values_supported\": [\n        \"RSA-OAEP\",\n        \"RSA-OAEP-256\",\n        \"A128KW\",\n        \"A256KW\",\n        \"RSA1_5\",\n        \"dir\",\n        \"A192KW\"\n    ],\n    \"grant_types_supported\": [\n        \"implicit\",\n        \"refresh_token\",\n        \"urn:ietf:params:oauth:grant-type:saml2-bearer\",\n        \"password\",\n        \"client_credentials\",\n        \"urn:ietf:params:oauth:grant-type:device_code\",\n        \"authorization_code\",\n        \"urn:ietf:params:oauth:grant-type:uma-ticket\"\n    ],\n    \"end_session_endpoint\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/connect/endSession\",\n    \"rcs_request_encryption_enc_values_supported\": [\n        \"A256GCM\",\n        \"A192GCM\",\n        \"A128GCM\",\n        \"A128CBC-HS256\",\n        \"A192CBC-HS384\",\n        \"A256CBC-HS512\"\n    ],\n    \"version\": \"3.0\",\n    \"rcs_response_encryption_alg_values_supported\": [\n        \"RSA-OAEP\",\n        \"RSA-OAEP-256\",\n        \"A128KW\",\n        \"A256KW\",\n        \"RSA1_5\",\n        \"dir\",\n        \"A192KW\"\n    ],\n    \"userinfo_endpoint\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/userinfo\",\n    \"token_endpoint_auth_signing_alg_values_supported\": [\n        \"PS384\",\n        \"RS384\",\n        \"ES384\",\n        \"HS256\",\n        \"HS512\",\n        \"ES256\",\n        \"RS256\",\n        \"HS384\",\n        \"ES512\",\n        \"PS256\",\n        \"PS512\",\n        \"RS512\"\n    ],\n    \"id_token_encryption_alg_values_supported\": [\n        \"RSA-OAEP\",\n        \"RSA-OAEP-256\",\n        \"A128KW\",\n        \"A256KW\",\n        \"RSA1_5\",\n        \"dir\",\n        \"A192KW\"\n    ],\n    \"jwks_uri\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/connect/jwk_uri\",\n    \"subject_types_supported\": [\n        \"public\"\n    ],\n    \"id_token_signing_alg_values_supported\": [\n        \"PS384\",\n        \"ES384\",\n        \"RS384\",\n        \"HS256\",\n        \"HS512\",\n        \"ES256\",\n        \"RS256\",\n        \"HS384\",\n        \"ES512\",\n        \"PS256\",\n        \"PS512\",\n        \"RS512\"\n    ],\n    \"registration_endpoint\": \"https://openam-{{tenantName}}.forgeblocks.com/oauth2/register\",\n    \"request_object_signing_alg_values_supported\": [\n        \"PS384\",\n        \"ES384\",\n        \"RS384\",\n        \"HS256\",\n        \"HS512\",\n        \"ES256\",\n        \"RS256\",\n        \"HS384\",\n        \"ES512\",\n        \"PS256\",\n        \"PS512\",\n        \"RS512\"\n    ],\n    \"request_object_encryption_alg_values_supported\": [\n        \"RSA-OAEP\",\n        \"RSA-OAEP-256\",\n        \"A128KW\",\n        \"RSA1_5\",\n        \"A256KW\",\n        \"dir\",\n        \"A192KW\"\n    ],\n    \"rcs_response_signing_alg_values_supported\": [\n        \"PS384\",\n        \"ES384\",\n        \"RS384\",\n        \"HS256\",\n        \"HS512\",\n        \"ES256\",\n        \"RS256\",\n        \"HS384\",\n        \"ES512\",\n        \"PS256\",\n        \"PS512\",\n        \"RS512\"\n    ]\n}"
+						}
+					]
+				}
+			],
+			"description": "Supports authentication of users to access apps. Some Authentication API endpoints support creation of app and user access tokens. You can then use those access tokens in the Management API.\n\nYou can use these REST calls to build authentication into your apps.\n\nTo take full advantage of the Management API, include appropriate scopes in requests to authorization endpoints. The Authentication API then includes the scope in the output access token. For more information, see our documentation on <a href=\"https://developer-cloud.forgerock.com/reference/scopes/\" target=\"_blank\">scopes</a>.",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "2b0ceab8-13c5-48ca-8092-708651935099",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "d3b829d4-6dbe-44d8-9e63-f3643d0e43a5",
 						"type": "text/javascript",
 						"exec": [
 							""

--- a/ForgeRock Environment Vars 0.4.postman_environment.json
+++ b/ForgeRock Environment Vars 0.4.postman_environment.json
@@ -1,0 +1,179 @@
+{
+	"id": "54c6ede9-6946-4056-918e-806d9f61b633",
+	"name": "ForgeRock Environment Vars 0.4",
+	"values": [
+		{
+			"key": "tenantApiV1Url",
+			"value": "https://api-{{tenantName}}.forgeblocks.com/v1",
+			"enabled": true
+		},
+		{
+			"key": "oauth2Url",
+			"value": "https://openam-{{tenantName}}.forgeblocks.com/am/oauth2",
+			"enabled": true
+		},
+		{
+			"key": "authRealmsUrl",
+			"value": "https://openam-{{tenantName}}.forgeblocks.com/am/",
+			"enabled": true
+		},
+		{
+			"key": "loginUrl",
+			"value": "https://example.com/homeLogin/",
+			"enabled": true
+		},
+		{
+			"key": "logoutUrl",
+			"value": "https://example.com/homeLogout/",
+			"enabled": true
+		},
+		{
+			"key": "tenantName",
+			"value": "{{name_of_your_tenant}}",
+			"enabled": true
+		},
+		{
+			"key": "accessToken",
+			"value": "{{adminConsoleAccessToken}}",
+			"enabled": true
+		},
+		{
+			"key": "appAccessToken",
+			"value": "{{web_app_access_token}}",
+			"enabled": true
+		},
+		{
+			"key": "spaAppAccessToken",
+			"value": "{{spa_app_access_token}}",
+			"enabled": true
+		},
+		{
+			"key": "userName",
+			"value": "{{userName}}",
+			"enabled": true
+		},
+		{
+			"key": "userPassword",
+			"value": "Passwordy1#",
+			"enabled": true
+		},
+		{
+			"key": "serviceClientId",
+			"value": "{{serviceClientId}}",
+			"enabled": true
+		},
+		{
+			"key": "serviceClientSecret",
+			"value": "{{serviceClientSecret}}",
+			"enabled": true
+		},
+		{
+			"key": "scopes",
+			"value": "me.read me.update password-policy.read password-policy.update user.reset-password user.recover-username user.create user.read openid profile email",
+			"enabled": true
+		},
+		{
+			"key": "userAccessToken",
+			"value": "{{userAccessToken}}",
+			"enabled": true
+		},
+		{
+			"key": "userId",
+			"value": "{{user_id}}",
+			"enabled": true
+		},
+		{
+			"key": "userIdToken",
+			"value": "{{userIdToken}}",
+			"enabled": true
+		},
+		{
+			"key": "userProperty",
+			"value": "userName",
+			"enabled": true
+		},
+		{
+			"key": "refreshToken",
+			"value": "{{refreshToken}}",
+			"enabled": true
+		},
+		{
+			"key": "code",
+			"value": "{{authCode_from_webApp}}",
+			"enabled": true
+		},
+		{
+			"key": "iPlanetDirectoryPro",
+			"value": "{{iPlanetDirectoryPro_cookie}}",
+			"enabled": true
+		},
+		{
+			"key": "comparator",
+			"value": "{{comparator}}",
+			"enabled": true
+		},
+		{
+			"key": "value",
+			"value": "{{valueOfFilter}}",
+			"enabled": true
+		},
+		{
+			"key": "parameter",
+			"value": "{{filterType}}",
+			"enabled": true
+		},
+		{
+			"key": "m2mAppClientId",
+			"value": "{{client_id_of_spa_app}}",
+			"enabled": true
+		},
+		{
+			"key": "m2mAppClientSecret",
+			"value": "{{m2mSpaClientSecret}}",
+			"enabled": true
+		},
+		{
+			"key": "webAppClientId",
+			"value": "{{client_id_of_web_app}}",
+			"enabled": true
+		},
+		{
+			"key": "webAppClientSecret",
+			"value": "{{client_secret_of_web_app))",
+			"enabled": true
+		},
+		{
+			"key": "spaAppClientId",
+			"value": "{{spa_app_client_id}}",
+			"enabled": true
+		},
+		{
+			"key": "spaAppClientSecret",
+			"value": "{{spa_app_client_secret}}",
+			"enabled": true
+		},
+		{
+			"key": "authorizationCode",
+			"value": "{{PKCE_based}}",
+			"enabled": true
+		},
+		{
+			"key": "authTree",
+			"value": "{{authentication_tree}}",
+			"enabled": true
+		},
+		{
+			"key": "ssoToken",
+			"value": "{{iPlanetDirectoryPro}}",
+			"enabled": true
+		},
+		{
+			"key": "spaScopes",
+			"value": "me.read me.update password-policy.read password-policy.update user.reset-password user.recover-username user.create user.read openid profile email",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2019-07-09T14:55:00.956Z",
+	"_postman_exported_using": "Postman/7.2.2"
+}


### PR DESCRIPTION
Update, July 1. Everything works! I've asked @markcraig to go through this from a Doc PoV (and he's more up to speed on OAuth2/OIDC thank I :))

To review this PR, I'd take the following steps: (My plan -- to set up this procedure in FRAAS-18)

0) Install Postman
1) Set up tenant, and log in (staging.forgeblocks.com)
1a) You'll need the tenant name, and the tenant access token from the dev console of your browser (it's associated with the session endpoint)
2) Download 
* 'ForgeRock Cloud APIs.postman_collection.json' (when you import it, you'll see it with a *(June 2019)* label
* 'ForgeRock Environment Vars 0.4.postman_environment.json'
3) Import files into Postman
4) Go into the environment (gear icon, upper right), and add
* tenant name
* access token
5) Compare text online, between two browsers:
* In your Postman app, find the arrow next to the collection, select "View in Web". That'll open up the web view in your default browser. (Or you can view it [here](https://cloud-forgerock.postman.co/collections/2524838-31f4f249-1e1c-4879-a416-4ad47bfa386b?version=latest&workspace=5533728c-a163-41f0-8d6d-ef9ea3d3cc4e))
(or if you have a space in our Postman Pro account, navigate to https://cloud-forgerock.postman.co/collections/2524838-0a6cda2f-98db-4a80-9c81-2af373e9db7e?version=latest&workspace=700e189a-c68e-4f6f-be16-bda221125d76 ) 
* In a second browser, navigate to developer-api.forgerock.com

Major changes:

1) I've made the calls more sequential. Example, under Management APIs / Apps / Web, you can run the commands sequentially, to demo create, update, regenerate secret, delete.
2) I've moved the Management APIs first, as some of those are prereqs to Authentication API calls.