### PR TITLE
[FRAAS-23] Include link from Postman collection to desc of env variables

### DIFF
--- a/Express Beta APIs.postman_collection.json
+++ b/Express Beta APIs.postman_collection.json
@@ -2,7 +2,7 @@
 	"info": {
 		"_postman_id": "845921cb-7275-4223-827f-c98b3335c86f",
 		"name": "Express Beta APIs",
-		"description": "The ForgeRock Identity Cloud includes two sets of APIs:\n\n* Management APIs: To manage configuration of Express \n\n* Authentication APIs: To authenticate users and obtain and manage `access_token`, `id_token` and `refresh_token`\n\n(Git commit 8ae35679)\n",
+                "description": "The ForgeRock Identity Cloud includes two sets of APIs:\n\n* Management APIs: To manage configuration of ForgeRock Identity Cloud Express\n\n* Authentication APIs: To authenticate users and obtain and manage `access_token`, `id_token` and `refresh_token`.\n\nFor descriptions of environment variables, see our Glossary of [Postman Variables](https://developer.forgerock.com/docs/identity-cloud/reference/postman-variables).",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [


### PR DESCRIPTION
This is the companion PR to [this PR on the dev docs](https://www.google.com/search?client=ubuntu&channel=fs&q=oauth+%22authentication+context%22&ie=utf-8&oe=utf-8)

Here's how the text would look (updated 8 Oct)

![Screenshot from 2019-10-08 16-24-20](https://user-images.githubusercontent.com/3287976/66440534-255c4800-e9e8-11e9-89c5-ea23f9dd1181.png)



The link in the last visible line is intended to go to the new Postman Variables reference page